### PR TITLE
modules: point the firmware at a go-haystack commit on main

### DIFF
--- a/firmware/go.mod
+++ b/firmware/go.mod
@@ -3,7 +3,7 @@ module github.com/hybridgroup/go-haystack/firmware
 go 1.25.0
 
 require (
-	github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e
+	github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad
 	tinygo.org/x/bluetooth v0.16.1-0.20260908143722-deba7de3cc05
 )
 

--- a/firmware/go.sum
+++ b/firmware/go.sum
@@ -9,6 +9,8 @@ github.com/hybridgroup/go-haystack v0.1.1-0.20250820102311-570b3a760002 h1:WPAly
 github.com/hybridgroup/go-haystack v0.1.1-0.20250820102311-570b3a760002/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
 github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e h1:TLGJbUNJhamlQz77+8cC9dDhh7zMdkINTOFR6m/22Js=
 github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
+github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad h1:UkLRlJO3TAayNu/oeyr0aomuH74EJLp2kZt+B9I1RCA=
+github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Why

The firmware module needs `NewDataWithStatus` from the root module, so #23 pinned the
commit of its own branch. That is correct while the PR is open, and it is what let the
firmware build there.

#23 was rebase merged, so its four commits went onto `main` with new hashes, and the
branch was then deleted. `firmware/go.mod` on `main` therefore points at
`a1b345b4d96e`, which no branch reaches.

## Is anything broken now

No, and this is not urgent. The version still resolves, because the module proxy holds
it and GitHub still serves the object. I checked this with a fresh clone and
`GOPROXY=direct`, and the download passed.

It is still wrong, because the pin depends on GitHub keeping an object that no branch
reaches. GitHub can collect it at any time, and the build then fails for everyone.

## What this does

Point the pin at `1e4cb69`, which is the tip of `main` and holds `NewDataWithStatus`.

`tinygo.org/x/bluetooth` does not change. It points at a `dev` commit of that
repository, which is reachable. Move it to a release when one holds `SetTxPower` and
`EnableDCSupply`, because v0.16.0 is older than the merge.

## Test

`gofmt` is clean, and `go build`, `go vet` and `go test` pass for the root,
`cmd/haystack` and `firmware` modules. `tinygo build` passes for `xiao-ble`,
`nicenano`, `feather-nrf52840` and `nano-rp2040`.