### PR TITLE
Add support for the ESP32-C3 and the ESP32-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ As a result, any of the following hardware devices should work:
 - [Seeed Studio XIAO nRF52840](https://wiki.seeedstudio.com/XIAO_BLE)
 - [Other Nordic Semi SoftDevice boards](https://github.com/tinygo-org/bluetooth?tab=readme-ov-file#flashing-the-softdevice-on-other-boards)
 - [Boards using the NINA-FW with an ESP32 co-processor](https://github.com/tinygo-org/bluetooth?tab=readme-ov-file#esp32-nina)
+- [Espressif ESP32-C3 and ESP32-S3 boards that use the radio in the chip](https://github.com/tinygo-org/bluetooth?tab=readme-ov-file#esp32), such as the Seeed XIAO ESP32C3 and the XIAO ESP32S3. The targets are `xiao-esp32c3`, `xiao-esp32s3`, `esp32c3-supermini`, `esp32s3-supermini`, `esp32c3-generic`, `esp32s3-generic`, `qtpy-esp32c3` and `m5stamp-c3`. These boards need TinyGo 0.42 or later.
 - [Boards such as the RP2040 Pico-W using the CYW43439 co-processor](https://github.com/tinygo-org/bluetooth?tab=readme-ov-file#cyw43439-rp2040-w)
 
 The beacon code is located in this repository in the [firmware](./firmware/) directory.
@@ -67,8 +68,16 @@ Only turn it on if you can measure that it helps:
 -ldflags="-X main.AdvertisingKey='$ADVKEY' -X main.DCDC0=on"
 ```
 
-These settings need a Nordic SoftDevice board. On any other board the firmware prints
-a message and goes on with the default behaviour.
+`DCDC`, `DCDC0` and `TxPower` all need a Nordic board that is built with a SoftDevice.
+The firmware ignores `DCDC` and `DCDC0` on every other board. `TxPower` prints a message
+there, and the radio keeps its default power.
+
+An ESP32-C3 or ESP32-S3 beacon uses much more current than a Nordic beacon. The firmware
+does not sleep on these boards, and the Bluetooth package keeps a loop that reads the
+radio every 5 milliseconds. Use a larger battery, or use a Nordic board if the device must
+run for a long time. The `-serial=none` flag gains almost nothing on these boards, because
+the console is part of the USB block that stays on, so `haystack flash -battery` does not
+use it there.
 
 ### Battery status
 
@@ -81,8 +90,51 @@ minutes, and it only restarts the advertisement when the status changes.
 | Seeed XIAO nRF52840 | 1M and 510k divider on P0.31, connected by P0.14 |
 | nice!nano v2 | VDDH/5 on an internal channel, no divider |
 | Adafruit Feather nRF52840 | Two 150k resistors on P0.29, which the board calls A6 |
+| Seeed XIAO ESP32C3 | A divider that you add, on an ADC1 pin. See below |
+| Seeed XIAO ESP32S3 | A divider that you add, on an ADC1 pin. See below |
 
 Any other board reports a full battery, as before.
+
+#### A battery divider on an ESP32-C3 or ESP32-S3
+
+No XIAO ESP32 board connects the battery to an ADC pin, so you must add a divider of two
+resistors from the battery to a pin. Then give the firmware the pin and the ratio, and it
+reads the battery in the same way as a Nordic board:
+
+```shell
+haystack -batterypin=2 -batterydivider=2/1 flash DEVICENAME xiao-esp32c3
+```
+
+The same values with `tinygo` alone:
+
+```
+-ldflags="-X main.AdvertisingKey='$ADVKEY' -X main.BatteryPin=2 -X main.BatteryDivider=2/1"
+```
+
+`BatteryPin` is the GPIO number and not the name of the pin. On the XIAO ESP32C3, A0 is
+GPIO2. On the XIAO ESP32S3, A0 is GPIO1.
+
+`BatteryDivider` is the full resistance divided by the resistance across the pin. Two
+resistors of the same value give `2/1`, which you can also write as `2`. A 1M and a 510k
+resistor give `1510/510`.
+
+Some rules for the divider:
+
+- The pin must be an ADC1 pin, which is GPIO0 to GPIO4 on the ESP32-C3 and GPIO1 to GPIO10
+  on the ESP32-S3. The other pins are ADC2, which shares its hardware with the radio and
+  gives noisy values.
+- Choose the resistors so that a full 4200 mV battery gives less than about 2500 mV at the
+  pin. This needs a ratio of 2 or more, and it keeps the reading in the range where the
+  ADC is linear.
+- Use large resistors, such as 1M and 1M, because the divider takes current from the
+  battery all the time.
+
+The firmware prints a message and reports a full battery if the values are not usable, so
+a wrong value cannot stop the beacon.
+
+The ADC on these chips has no calibration, so the voltage can be several percent wrong,
+and the thresholds are only 200 mV apart. To correct this, measure the battery with a
+multimeter one time, then change `BatteryDivider` until the message agrees with the meter.
 
 The thresholds suit a single cell LiPo, which is full at 4200 mV and empty at about
 3300 mV. They are the `battery...Millivolts` constants in
@@ -193,7 +245,8 @@ This will use TinyGo to compile the firmware using your keys, and then flash it 
 
 For a device on a battery, add `-battery`, which turns the serial port off. Add
 `-txpower` to lower the radio transmit power, which saves more current but shortens
-the range. All flags go before the subcommand. See
+the range. On an ESP32-C3 or ESP32-S3 board, add `-batterypin` and `-batterydivider` to
+read the battery. All flags go before the subcommand. See
 [Battery Powered Beacons](#battery-powered-beacons).
 
 ```shell

--- a/cmd/haystack/main.go
+++ b/cmd/haystack/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -15,6 +16,8 @@ func main() {
 	batteryFlag := flag.Bool("battery", false, "build for a device on a battery, which uses as little current as possible")
 	txPowerFlag := flag.String("txpower", "", "radio transmit power in dBm, for example -8. Empty keeps the default power")
 	dcdc0Flag := flag.Bool("dcdc0", false, "turn the DC/DC converter of the VDDH stage on. Needs a board powered through VDDH, and often gains nothing from a battery")
+	batteryPinFlag := flag.String("batterypin", "", "GPIO number that reads a battery divider, for example 2. Only an ESP32-C3 or ESP32-S3 board needs it")
+	batteryDividerFlag := flag.String("batterydivider", "", "ratio of the battery divider, for example 2/1. A single number is a ratio to 1")
 	flag.Parse()
 
 	args := flag.Args()
@@ -37,7 +40,15 @@ func main() {
 			fmt.Println("Please provide a device name and target")
 			return
 		}
-		if err := flashDevice(args[1], args[2], verboseFlag, batteryFlag, dcdc0Flag, txPowerFlag); err != nil {
+		opts := flashOptions{
+			verbose:        *verboseFlag,
+			battery:        *batteryFlag,
+			dcdc0:          *dcdc0Flag,
+			txPower:        *txPowerFlag,
+			batteryPin:     *batteryPinFlag,
+			batteryDivider: *batteryDividerFlag,
+		}
+		if err := flashDevice(args[1], args[2], opts); err != nil {
 			fmt.Println("failed to flash device:", err)
 		}
 	case "scan":
@@ -74,7 +85,35 @@ func generateKeys(name string, verboseFlag *bool) error {
 	return saveDevice(name, priv)
 }
 
-func flashDevice(name string, target string, verboseFlag, batteryFlag, dcdc0Flag *bool, txPowerFlag *string) error {
+// flashOptions holds the build settings that the flags give.
+type flashOptions struct {
+	verbose        bool
+	battery        bool
+	dcdc0          bool
+	txPower        string
+	batteryPin     string
+	batteryDivider string
+}
+
+// espTargets are the TinyGo targets that use the radio in an ESP32-C3 or
+// ESP32-S3 chip.
+var espTargets = []string{
+	"xiao-esp32c3",
+	"xiao-esp32s3",
+	"esp32c3-supermini",
+	"esp32s3-supermini",
+	"esp32c3-generic",
+	"esp32s3-generic",
+	"qtpy-esp32c3",
+	"m5stamp-c3",
+}
+
+// isESPTarget reports if the target uses the radio in an ESP32 chip.
+func isESPTarget(target string) bool {
+	return slices.Contains(espTargets, target)
+}
+
+func flashDevice(name string, target string, opts flashOptions) error {
 	key, err := readKey(name)
 	if err != nil {
 		return err
@@ -87,22 +126,39 @@ func flashDevice(name string, target string, verboseFlag, batteryFlag, dcdc0Flag
 	}
 	defer os.Chdir(pwd)
 
+	esp := isESPTarget(target)
+
 	keyVal := fmt.Sprintf("-X main.AdvertisingKey='%s'", key)
-	if *txPowerFlag != "" {
-		keyVal += fmt.Sprintf(" -X main.TxPower=%s", *txPowerFlag)
+	if opts.txPower != "" {
+		keyVal += fmt.Sprintf(" -X main.TxPower=%s", opts.txPower)
+		if esp {
+			fmt.Println("note: this target does not support the transmit power setting, so the radio keeps its default power")
+		}
 	}
-	if *dcdc0Flag {
+	if opts.dcdc0 {
 		keyVal += " -X main.DCDC0=on"
+	}
+	if opts.batteryPin != "" {
+		keyVal += fmt.Sprintf(" -X main.BatteryPin=%s", opts.batteryPin)
+	}
+	if opts.batteryDivider != "" {
+		keyVal += fmt.Sprintf(" -X main.BatteryDivider=%s", opts.batteryDivider)
 	}
 
 	args := []string{"flash", "-target", target}
-	if *batteryFlag {
-		// The USB peripheral uses current for no purpose on a battery.
-		args = append(args, "-serial=none")
+	if opts.battery {
+		if esp {
+			// The console of an ESP32-C3 or ESP32-S3 is part of the USB block,
+			// which stays on, so this only removes the messages.
+			fmt.Println("note: this target keeps its serial port, because turning it off saves almost no current and removes all messages")
+		} else {
+			// The USB peripheral uses current for no purpose on a battery.
+			args = append(args, "-serial=none")
+		}
 	}
 	args = append(args, "-ldflags", keyVal, ".")
 
-	if *verboseFlag {
+	if opts.verbose {
 		fmt.Println("tinygo", strings.Join(args, " "))
 	}
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -4,7 +4,14 @@ Any device supported by the TinyGo Bluetooth package can be used to create a bea
 
 ## How to flash
 
+A Nordic or RP2040 board:
+
 ```shell
 tinygo flash -target nano-rp2040 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
+```
 
+An ESP32-C3 or ESP32-S3 board, which uses the radio in the chip:
+
+```shell
+tinygo flash -target xiao-esp32c3 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
 ```

--- a/firmware/battery_config.go
+++ b/firmware/battery_config.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// batteryConfig returns the ADC pin and the divider ratio that BatteryPin and
+// BatteryDivider give. It returns false unless both values are usable.
+func batteryConfig() (uint8, uint32, uint32, bool) {
+	if BatteryPin == "" || BatteryDivider == "" {
+		return 0, 0, 0, false
+	}
+
+	pin, err := strconv.ParseUint(BatteryPin, 10, 8)
+	if err != nil {
+		println("bad BatteryPin value:", BatteryPin)
+		return 0, 0, 0, false
+	}
+
+	num, den, ok := parseDivider(BatteryDivider)
+	if !ok {
+		println("bad BatteryDivider value:", BatteryDivider)
+		return 0, 0, 0, false
+	}
+
+	return uint8(pin), num, den, true
+}
+
+// parseDivider reads a divider ratio such as "1510/510". A single number is a
+// ratio to 1, so "2" is the same as "2/1".
+func parseDivider(s string) (uint32, uint32, bool) {
+	numText, denText := s, "1"
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		numText, denText = s[:i], s[i+1:]
+	}
+
+	// The values stay in 16 bits so that batteryMillivolts cannot overflow.
+	num, err := strconv.ParseUint(numText, 10, 16)
+	if err != nil {
+		return 0, 0, false
+	}
+	den, err := strconv.ParseUint(denText, 10, 16)
+	if err != nil || den == 0 {
+		return 0, 0, false
+	}
+
+	// A divider lowers the voltage, so a numerator that is less than the
+	// denominator is a pair of values in the wrong order.
+	if num < den {
+		return 0, 0, false
+	}
+
+	return uint32(num), uint32(den), true
+}

--- a/firmware/battery_esp.go
+++ b/firmware/battery_esp.go
@@ -1,0 +1,51 @@
+// The tag is a copy of the tag on machine_esp32xx_adc.go in TinyGo, which is
+// the ADC driver that this file needs. The m5stamp-c3 has no driver.
+//go:build esp32s3 || (esp32c3 && !m5stamp_c3)
+
+package main
+
+import "machine"
+
+// batterySamples is the number of readings that readBatteryMillivolts averages.
+// The ESP32 ADC has no sample time control, so it needs more readings.
+const batterySamples = 16
+
+// adcReady tells if machine.InitADC ran. InitADC resets the SAR peripheral and
+// drives the analog bus, so it must run one time only and before the radio.
+var adcReady bool
+
+// readBatteryMillivolts returns the battery voltage in millivolts.
+//
+// The board has no battery divider, so BatteryPin and BatteryDivider must give
+// the pin and the ratio of a divider that the operator added.
+func readBatteryMillivolts() (uint16, bool) {
+	pin, num, den, ok := batteryConfig()
+	if !ok {
+		return 0, false
+	}
+
+	if pin < batteryFirstPin || pin > batteryLastPin {
+		println("BatteryPin is not an ADC1 pin:", BatteryPin)
+		return 0, false
+	}
+
+	if !adcReady {
+		machine.InitADC()
+		adcReady = true
+	}
+
+	adc := machine.ADC{Pin: machine.Pin(pin)}
+	// The driver sets the attenuation itself and does not read the config.
+	if err := adc.Configure(machine.ADCConfig{}); err != nil {
+		println("cannot configure battery ADC:", err.Error())
+		return 0, false
+	}
+
+	var total uint32
+	for i := 0; i < batterySamples; i++ {
+		total += uint32(adc.Get())
+	}
+	raw := total / batterySamples
+
+	return batteryMillivolts(raw, batteryReference, num, den), true
+}

--- a/firmware/battery_esp32c3.go
+++ b/firmware/battery_esp32c3.go
@@ -1,0 +1,14 @@
+//go:build esp32c3 && !m5stamp_c3
+
+package main
+
+const (
+	// The ADC uses 11 dB attenuation, which gives a full scale of about 3300
+	// mV. See machine_esp32s3_adc.go in TinyGo, which states this scale.
+	batteryReference = 3300
+
+	// ADC1 is GPIO0 to GPIO4. GPIO5 is ADC2, which shares its arbiter with
+	// the radio and gives noisy readings.
+	batteryFirstPin = 0
+	batteryLastPin  = 4
+)

--- a/firmware/battery_esp32s3.go
+++ b/firmware/battery_esp32s3.go
@@ -1,0 +1,14 @@
+//go:build esp32s3
+
+package main
+
+const (
+	// The ADC uses 11 dB attenuation, which gives a full scale of about 3300
+	// mV. See machine_esp32s3_adc.go in TinyGo, which states this scale.
+	batteryReference = 3300
+
+	// ADC1 is GPIO1 to GPIO10. ADC2 shares its arbiter with the radio, and
+	// GPIO19 and GPIO20 are the USB data pins.
+	batteryFirstPin = 1
+	batteryLastPin  = 10
+)

--- a/firmware/battery_other.go
+++ b/firmware/battery_other.go
@@ -1,4 +1,4 @@
-//go:build !xiao_ble && !nicenano && !feather_nrf52840
+//go:build !(xiao_ble || nicenano || feather_nrf52840 || esp32s3 || (esp32c3 && !m5stamp_c3))
 
 package main
 

--- a/firmware/go.mod
+++ b/firmware/go.mod
@@ -3,7 +3,7 @@ module github.com/hybridgroup/go-haystack/firmware
 go 1.25.0
 
 require (
-	github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e
+	github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad
 	tinygo.org/x/bluetooth v0.16.1-0.20260908143722-deba7de3cc05
 )
 

--- a/firmware/go.sum
+++ b/firmware/go.sum
@@ -9,6 +9,8 @@ github.com/hybridgroup/go-haystack v0.1.1-0.20250820102311-570b3a760002 h1:WPAly
 github.com/hybridgroup/go-haystack v0.1.1-0.20250820102311-570b3a760002/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
 github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e h1:TLGJbUNJhamlQz77+8cC9dDhh7zMdkINTOFR6m/22Js=
 github.com/hybridgroup/go-haystack v0.1.1-0.20260908104937-a1b345b4d96e/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
+github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad h1:UkLRlJO3TAayNu/oeyr0aomuH74EJLp2kZt+B9I1RCA=
+github.com/hybridgroup/go-haystack v0.1.1-0.20260908150425-1e4cb69862ad/go.mod h1:szTPNk5yX2h/itElVA1WSGmsezghEaxByfciUiNm9Bo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/firmware/main.go
+++ b/firmware/main.go
@@ -3,6 +3,7 @@
 //
 // To build:
 // tinygo flash -target nano-rp2040 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
+// tinygo flash -target xiao-esp32c3 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
 //
 // For a device on a battery, see the power settings in README.md.
 //
@@ -42,6 +43,8 @@ func main() {
 	}
 	println("key is", AdvertisingKey, "(", len(key), "bytes)")
 
+	// This first reading must stay before adapter.Enable below. On an ESP32 it
+	// starts the ADC, which must not happen while the radio runs.
 	millivolts, hasBattery := readBatteryMillivolts()
 	status := byte(findmy.StatusBatteryFull)
 	if hasBattery {
@@ -49,6 +52,8 @@ func main() {
 		println("battery is", strconv.Itoa(int(millivolts)), "mV,", findmy.BatteryStatus(status))
 	}
 
+	// The payload has no space left. A non-connectable advertisement holds 31
+	// bytes, and the 2 byte company ID and the 27 byte payload fill it.
 	opts := bluetooth.AdvertisementOptions{
 		AdvertisementType: bluetooth.AdvertisingTypeNonConnInd,
 		Interval:          bluetooth.NewDuration(advertisingInterval),
@@ -59,7 +64,7 @@ func main() {
 
 	// The DC/DC converter lowers the current a lot, but the board must have the
 	// inductor. Set DCDC to "off" for a board that does not have it.
-	if dcdcEnabled() {
+	if dcdcAvailable && dcdcEnabled() {
 		if err := adapter.EnableDCSupply(bluetooth.DCSupplyMain, true); err != nil {
 			println("cannot enable DCDC:", err.Error())
 		}
@@ -67,13 +72,14 @@ func main() {
 
 	// The VDDH stage needs a board that is powered through VDDH, and it gains
 	// little unless VDDH is much higher than VDD. It is off unless asked for.
-	if dcdc0Enabled() {
+	if dcdcAvailable && dcdc0Enabled() {
 		if err := adapter.EnableDCSupply(bluetooth.DCSupplyHighVoltage, true); err != nil {
 			println("cannot enable DCDC0:", err.Error())
 		}
 	}
 
-	// Set the address to the first 6 bytes of the public key.
+	// Set the address to the first 6 bytes of the public key. This call must
+	// stay between Enable and Start, because each one needs it.
 	adapter.SetRandomAddress(bluetooth.MAC{key[5], key[4], key[3], key[2], key[1], key[0] | 0xC0})
 
 	println("configure advertising...")
@@ -90,12 +96,13 @@ func main() {
 
 	println("start advertising...")
 	must("start adv", adv.Start())
+	advertising := true
 
 	address, _ := adapter.Address()
 	println("FindMy device using", address.MAC.String())
 
-	// The BLE stack advertises on its own from here, so the CPU only wakes to
-	// read the battery. A board that cannot read it parks for good.
+	// A Nordic radio advertises on its own from here, so the CPU only wakes to
+	// read the battery. A radio on the HCI path keeps a poll loop running.
 	for {
 		if !hasBattery {
 			time.Sleep(time.Hour)
@@ -117,10 +124,17 @@ func main() {
 
 		// The BLE stack refuses a new set of parameters while it advertises, so
 		// stop before the payload changes.
-		if err := adv.Stop(); err != nil {
-			println("cannot stop adv:", err.Error())
-			continue
+		//
+		// Stop must never run if Start failed. On the HCI path Stop waits for
+		// the poll loop that Start makes, and it waits for ever if none runs.
+		if advertising {
+			if err := adv.Stop(); err != nil {
+				println("cannot stop adv:", err.Error())
+				continue
+			}
+			advertising = false
 		}
+
 		// A failure here must not stop the device being found, so it goes on
 		// and always tries to advertise again.
 		opts.ManufacturerData = []bluetooth.ManufacturerDataElement{findmy.NewDataWithStatus(key, status)}
@@ -129,7 +143,9 @@ func main() {
 		}
 		if err := adv.Start(); err != nil {
 			println("cannot start adv:", err.Error())
+			continue
 		}
+		advertising = true
 	}
 }
 

--- a/firmware/main_test.go
+++ b/firmware/main_test.go
@@ -93,6 +93,9 @@ func TestBatteryMillivolts(t *testing.T) {
 		{"feather_nrf52840", 45875, 3000, 2, 1, 4198},
 		// nice!nano v2: the internal channel sees VDDH/5, which is 840 mV.
 		{"nicenano", 18350, 3000, 5, 1, 4195},
+		// ESP32 with a 2 to 1 divider that the operator added, so the pin sees
+		// 2100 mV of a 3300 mV full scale.
+		{"esp32", 41705, 3300, 2, 1, 4200},
 	}
 
 	for _, tc := range tests {
@@ -137,6 +140,53 @@ func TestDCDC0Enabled(t *testing.T) {
 		DCDC0 = tc.dcdc0
 		if got := dcdc0Enabled(); got != tc.want {
 			t.Errorf("DCDC0=%q: got %v, want %v", tc.dcdc0, got, tc.want)
+		}
+	}
+}
+
+// TestBatteryConfig checks the values that BatteryPin and BatteryDivider give.
+func TestBatteryConfig(t *testing.T) {
+	// The other tests leave these values changed, so keep and put back the
+	// values that the build gave.
+	oldPin, oldDivider := BatteryPin, BatteryDivider
+	defer func() { BatteryPin, BatteryDivider = oldPin, oldDivider }()
+
+	tests := []struct {
+		pin, divider string
+		wantPin      uint8
+		wantNum      uint32
+		wantDen      uint32
+		wantOK       bool
+	}{
+		{"2", "2/1", 2, 2, 1, true},
+		{"0", "1510/510", 0, 1510, 510, true},
+		{"10", "2", 10, 2, 1, true},
+		{"1", "1/1", 1, 1, 1, true},
+		// No value stops the reading.
+		{"", "2/1", 0, 0, 0, false},
+		{"2", "", 0, 0, 0, false},
+		{"", "", 0, 0, 0, false},
+		// A denominator of zero cannot divide.
+		{"2", "2/0", 0, 0, 0, false},
+		// A divider lowers the voltage, so these two values are in the wrong
+		// order.
+		{"2", "510/1510", 0, 0, 0, false},
+		{"2", "abc", 0, 0, 0, false},
+		{"2", "/", 0, 0, 0, false},
+		{"2", "2/x", 0, 0, 0, false},
+		{"2", "-2", 0, 0, 0, false},
+		{"abc", "2/1", 0, 0, 0, false},
+		{"-1", "2/1", 0, 0, 0, false},
+		{"300", "2/1", 0, 0, 0, false},
+	}
+
+	for _, tc := range tests {
+		BatteryPin, BatteryDivider = tc.pin, tc.divider
+		pin, num, den, ok := batteryConfig()
+		if ok != tc.wantOK || pin != tc.wantPin || num != tc.wantNum || den != tc.wantDen {
+			t.Errorf("BatteryPin=%q BatteryDivider=%q: got %d %d %d %v, want %d %d %d %v",
+				tc.pin, tc.divider, pin, num, den, ok,
+				tc.wantPin, tc.wantNum, tc.wantDen, tc.wantOK)
 		}
 	}
 }

--- a/firmware/mcu.go
+++ b/firmware/mcu.go
@@ -17,3 +17,11 @@ var DCDC string
 // is powered through VDDH, and it often gains nothing from a battery. Only set
 // it to "on" if a measurement shows it helps.
 var DCDC0 string
+
+// BatteryPin is the GPIO number that reads a battery divider. An empty value
+// stops the reading. Set it with -ldflags "-X main.BatteryPin=2".
+var BatteryPin string
+
+// BatteryDivider is the ratio of the battery divider, such as "1510/510". A
+// single number is a ratio to 1. An empty value stops the reading.
+var BatteryDivider string

--- a/firmware/os.go
+++ b/firmware/os.go
@@ -18,3 +18,11 @@ var DCDC = "off"
 // DCDC0 turns the high voltage DC/DC regulator on. An operating system does not
 // give this control, so it stays empty here.
 var DCDC0 string
+
+// BatteryPin is the GPIO number that reads a battery divider. An operating
+// system does not give this control, so it stays empty here.
+var BatteryPin string
+
+// BatteryDivider is the ratio of the battery divider. An operating system does
+// not give this control, so it stays empty here.
+var BatteryDivider string

--- a/firmware/power_other.go
+++ b/firmware/power_other.go
@@ -1,0 +1,8 @@
+// The tag is a copy of the tag on adapter_dcsupply-other.go in the bluetooth
+// package, where EnableDCSupply always gives an error.
+//go:build !(softdevice && (s113v7 || s132v6 || s140v6 || s140v7))
+
+package main
+
+// dcdcAvailable tells if the radio has the DC/DC regulator calls.
+const dcdcAvailable = false

--- a/firmware/power_softdevice.go
+++ b/firmware/power_softdevice.go
@@ -1,0 +1,8 @@
+// The tag is a copy of the tag on adapter_dcsupply-other.go in the bluetooth
+// package, which is the only build that has the real EnableDCSupply call.
+//go:build softdevice && (s113v7 || s132v6 || s140v6 || s140v7)
+
+package main
+
+// dcdcAvailable tells if the radio has the DC/DC regulator calls.
+const dcdcAvailable = true


### PR DESCRIPTION
The bluetooth package has a native backend for the radio in the ESP32-C3 and the
ESP32-S3, so a board such as the Seeed XIAO ESP32C3 can be a beacon with no
co-processor. The firmware already compiled for these boards, but three problems
made them difficult to use.

## Use the DC/DC regulator calls only where they exist

The firmware always printed `cannot enable DCDC` at start up. The call exists
only in a SoftDevice build of the bluetooth package. A new `dcdcAvailable`
constant guards the two calls, and its build tag is a copy of the tag in the
bluetooth package. Thus a Nordic board without a SoftDevice also no longer gives
the message.

## Read the battery on an ESP32

No XIAO ESP32 board connects the battery to an ADC pin, so the reader stays off
unless `BatteryPin` and `BatteryDivider` give the pin and the ratio of a divider
that the operator added:

```shell
haystack -batterypin=2 -batterydivider=2/1 flash DEVICENAME xiao-esp32c3
```

The reader accepts an ADC1 pin only, because ADC2 shares its hardware with the
radio. It starts the ADC one time and before the radio, because `InitADC` resets
the SAR peripheral and drives the analog bus. If a value is not usable, it gives
a message and reports a full battery, so a wrong value cannot stop the beacon.

## Do not stop an advertisement that did not start

On the HCI path, `Stop` waits for the poll loop that `Start` makes, and it waits
for ever if `Start` failed. The battery loop printed a failure from `Start` and
continued, so the device stopped for good at the next battery change, with the
radio off and no message. The loop now keeps the state of the advertisement.

## Also in this change

- `haystack flash` has the `-batterypin` and `-batterydivider` flags.
- `haystack flash -battery` no longer adds `-serial=none` for an ESP32 target.
  The console is part of the USB block, which stays on, so the flag saves almost
  no current and only removes the messages.
- `haystack flash` gives a warning if `-txpower` has a value and the target is an
  ESP32 target, because the bluetooth package does not support that call there.
- The README gives the targets, the rules for a battery divider, and the current
  that these boards use.

## Tests

- The host tests pass, with a new table test for the battery values and a new row
  for an ESP32 divider.
- These 8 targets compile, with the battery values and without them:
  `xiao-esp32c3`, `xiao-esp32s3`, `esp32c3-supermini`, `esp32s3-supermini`,
  `esp32c3-generic`, `esp32s3-generic`, `qtpy-esp32c3`, `m5stamp-c3`. TinyGo has
  no ADC driver for the m5stamp-c3, so that board keeps the reader that gives no
  battery.
- `xiao-ble`, `nicenano`, `feather-nrf52840`, `nano-rp2040`, `pico-w` and
  `microbit-v2-s113v7` all compile, and the Linux beacon also compiles.
- Not yet done on hardware. The flash, the scan, a real divider and a change of
  the battery status need a board.