### PR TITLE
haystack: rotate the keys of a beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,48 @@ The thresholds suit a single cell LiPo, which is full at 4200 mV and empty at ab
 [firmware/battery.go](./firmware/battery.go). A device with a different cell, such as a
 coin cell, needs different values there.
 
+## Rotating Keys
+
+A beacon that always sends the same key can be followed by anybody who scans for it. To
+stop this, a device gets a set of keys, and the beacon uses them one after the other. The
+key and the Bluetooth address both change together, because the address is the first 6
+bytes of the key.
+
+`haystack keys` makes 12 keys, and the beacon uses each key for 5 minutes. The set lasts
+one hour and then starts again. The first key goes into `privateKey` in the JSON file and
+the others go into `additionalKeys`, which macless-haystack also fetches reports for, so
+the web UI shows one device with one history.
+
+Use `-keys` for the size of the set and `-rotate` for the time on each key:
+
+```shell
+haystack -keys=24 keys DEVICENAME
+haystack -rotate=15m flash DEVICENAME xiao-ble
+```
+
+More keys give a longer time before the set repeats, but macless-haystack then asks the
+endpoint for more keys at each refresh. A set of 24 keys with `-rotate=1h` covers a day.
+
+`-keys=1` gives the behavior of the older versions, which is one key for ever. An
+`-rotate` of `0s`, or an empty value, also keeps the first key for ever.
+
+The rotation needs both parts, so a device that already has a key file with one key keeps
+that one key until you make a new set. A device that gets a new set also needs its JSON
+file imported into macless-haystack again.
+
 ## Linux Beacons
 
 You can also run the beacon code on any Linux that has Bluetooth hardware, such as a Raspberry Pi or other embedded system.
 
 The beacon code is the same for embedded Linux as for microcontrollers, and is located in this repo in the [firmware](./firmware/) directory.
+
+Give it the keys as one argument, separated by commas, and the time on each key as a
+second argument:
+
+```shell
+cd firmware
+go run . KEY1,KEY2,KEY3 5m
+```
 
 ## TinyScan
 
@@ -232,6 +269,9 @@ haystack keys DEVICENAME
 
 The keys will be saved in a file named `DEVICENAME.keys` and the configuration file for Haystack will be saved in `DEVICENAME.json`. Replace "DEVICENAME" with whatever you want to name the actual device.
 
+This makes a set of 12 keys, which the beacon uses in turn. Add `-keys` for a different
+number. See [Rotating Keys](#rotating-keys).
+
 
 2. Flash the hardware with the TinyGo target and the name of your device.
 
@@ -246,8 +286,9 @@ This will use TinyGo to compile the firmware using your keys, and then flash it 
 For a device on a battery, add `-battery`, which turns the serial port off. Add
 `-txpower` to lower the radio transmit power, which saves more current but shortens
 the range. On an ESP32-C3 or ESP32-S3 board, add `-batterypin` and `-batterydivider` to
-read the battery. All flags go before the subcommand. See
-[Battery Powered Beacons](#battery-powered-beacons).
+read the battery. Add `-rotate` for a different time on each key. All flags go before the
+subcommand. See [Battery Powered Beacons](#battery-powered-beacons) and
+[Rotating Keys](#rotating-keys).
 
 ```shell
 haystack -battery -txpower=-8 flash DEVICENAME xiao-ble

--- a/cmd/haystack/keys.go
+++ b/cmd/haystack/keys.go
@@ -47,3 +47,47 @@ func generateKey() (string, string, string, error) {
 
 	return privateKeyBase64, publicKeyBase64, hashBase64, nil
 }
+
+// keySetTries is the number of times generateKeySet asks for a key that has a
+// usable hash. About half of all keys hold a '/' in the hash.
+const keySetTries = 100
+
+// generateKeySet returns count keys as three lists, the private keys, the
+// advertisement keys and the hashed advertisement keys.
+func generateKeySet(count int) ([]string, []string, []string, error) {
+	if count < 1 {
+		return nil, nil, nil, errors.New("Key count must be 1 or more")
+	}
+
+	privs := make([]string, 0, count)
+	pubs := make([]string, 0, count)
+	hashes := make([]string, 0, count)
+
+	for i := 0; i < count; i++ {
+		priv, pub, hash, err := generateKeyWithRetry()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		privs = append(privs, priv)
+		pubs = append(pubs, pub)
+		hashes = append(hashes, hash)
+	}
+
+	return privs, pubs, hashes, nil
+}
+
+// generateKeyWithRetry returns a key that has a hash without a '/'.
+func generateKeyWithRetry() (string, string, string, error) {
+	for i := 0; i < keySetTries; i++ {
+		priv, pub, hash, err := generateKey()
+		if err == errInvalidHash {
+			continue
+		}
+		if err != nil {
+			return "", "", "", err
+		}
+		return priv, pub, hash, nil
+	}
+
+	return "", "", "", errInvalidHash
+}

--- a/cmd/haystack/keys_test.go
+++ b/cmd/haystack/keys_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestGenerateKeySet checks the count, the content and the hashes of a set.
+func TestGenerateKeySet(t *testing.T) {
+	for _, count := range []int{1, 3, 12} {
+		privs, pubs, hashes, err := generateKeySet(count)
+		if err != nil {
+			t.Errorf("count %d: %v", count, err)
+			continue
+		}
+		if len(privs) != count || len(pubs) != count || len(hashes) != count {
+			t.Errorf("count %d: got %d %d %d keys", count, len(privs), len(pubs), len(hashes))
+			continue
+		}
+
+		seen := make(map[string]bool, count)
+		for i := range privs {
+			if seen[privs[i]] {
+				t.Errorf("count %d: key %d is a repeat", count, i)
+			}
+			seen[privs[i]] = true
+
+			// macless-haystack puts the hash in a URL path, so a '/' in it
+			// stops the reports.
+			if strings.Contains(hashes[i], "/") {
+				t.Errorf("count %d: hash %d holds a '/'", count, i)
+			}
+
+			val, err := base64.StdEncoding.DecodeString(pubs[i])
+			if err != nil || len(val) != 28 {
+				t.Errorf("count %d: adv key %d is %d bytes, %v", count, i, len(val), err)
+			}
+		}
+	}
+
+	if _, _, _, err := generateKeySet(0); err == nil {
+		t.Error("count 0: got no error, want one")
+	}
+}
+
+// TestSaveAndReadKeys checks that the file keeps the keys in order.
+func TestSaveAndReadKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{"one", 1},
+		{"twelve", 12},
+	}
+
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(old)
+
+	for _, tc := range tests {
+		privs, pubs, hashes, err := generateKeySet(tc.count)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := saveKeys(tc.name, privs, pubs, hashes); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := readKeys(tc.name)
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if len(got) != tc.count {
+			t.Errorf("%s: got %d keys, want %d", tc.name, len(got), tc.count)
+			continue
+		}
+		for i := range got {
+			if got[i] != pubs[i] {
+				t.Errorf("%s: key %d is %q, want %q", tc.name, i, got[i], pubs[i])
+			}
+		}
+	}
+
+	if _, err := readKeys("missing"); err == nil {
+		t.Error("missing file: got no error, want one")
+	}
+
+	if err := os.WriteFile("empty.keys", []byte("nothing here\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readKeys("empty"); err == nil {
+		t.Error("file without a key: got no error, want one")
+	}
+}
+
+// TestSaveDevice checks the JSON file that macless-haystack reads.
+func TestSaveDevice(t *testing.T) {
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(old)
+
+	tests := []struct {
+		name  string
+		privs []string
+	}{
+		{"single", []string{"AAA"}},
+		{"set", []string{"AAA", "BBB", "CCC"}},
+	}
+
+	for _, tc := range tests {
+		if err := saveDevice(tc.name, tc.privs); err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := os.ReadFile(tc.name + ".json")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var devices []struct {
+			Name           string   `json:"name"`
+			PrivateKey     string   `json:"privateKey"`
+			AdditionalKeys []string `json:"additionalKeys"`
+		}
+		if err := json.Unmarshal(b, &devices); err != nil {
+			t.Errorf("%s: %v\n%s", tc.name, err, b)
+			continue
+		}
+		if len(devices) != 1 {
+			t.Errorf("%s: got %d devices, want 1", tc.name, len(devices))
+			continue
+		}
+
+		dev := devices[0]
+		if dev.Name != tc.name {
+			t.Errorf("%s: name is %q", tc.name, dev.Name)
+		}
+		if dev.PrivateKey != tc.privs[0] {
+			t.Errorf("%s: privateKey is %q, want %q", tc.name, dev.PrivateKey, tc.privs[0])
+		}
+		if len(dev.AdditionalKeys) != len(tc.privs)-1 {
+			t.Errorf("%s: got %d additional keys, want %d", tc.name, len(dev.AdditionalKeys), len(tc.privs)-1)
+			continue
+		}
+		for i, key := range dev.AdditionalKeys {
+			if key != tc.privs[i+1] {
+				t.Errorf("%s: additional key %d is %q, want %q", tc.name, i, key, tc.privs[i+1])
+			}
+		}
+	}
+}

--- a/cmd/haystack/main.go
+++ b/cmd/haystack/main.go
@@ -18,6 +18,8 @@ func main() {
 	dcdc0Flag := flag.Bool("dcdc0", false, "turn the DC/DC converter of the VDDH stage on. Needs a board powered through VDDH, and often gains nothing from a battery")
 	batteryPinFlag := flag.String("batterypin", "", "GPIO number that reads a battery divider, for example 2. Only an ESP32-C3 or ESP32-S3 board needs it")
 	batteryDividerFlag := flag.String("batterydivider", "", "ratio of the battery divider, for example 2/1. A single number is a ratio to 1")
+	keysFlag := flag.Int("keys", defaultKeyCount, "how many keys to generate for a device, which the beacon then uses in turn")
+	rotateFlag := flag.String("rotate", defaultKeyRotation, "how long the beacon uses each key, for example 5m. An empty value stops the rotation")
 	flag.Parse()
 
 	args := flag.Args()
@@ -32,7 +34,7 @@ func main() {
 			fmt.Println("Please provide a device name")
 			return
 		}
-		if err := generateKeys(args[1], verboseFlag); err != nil {
+		if err := generateKeys(args[1], *keysFlag, *verboseFlag); err != nil {
 			fmt.Println("failed to generate keys:", err)
 		}
 	case "flash":
@@ -47,6 +49,7 @@ func main() {
 			txPower:        *txPowerFlag,
 			batteryPin:     *batteryPinFlag,
 			batteryDivider: *batteryDividerFlag,
+			rotate:         *rotateFlag,
 		}
 		if err := flashDevice(args[1], args[2], opts); err != nil {
 			fmt.Println("failed to flash device:", err)
@@ -61,29 +64,38 @@ func main() {
 	}
 }
 
-func generateKeys(name string, verboseFlag *bool) error {
+func generateKeys(name string, count int, verbose bool) error {
 	// TODO: check if overwriting keys
 
-	priv, pub, hash, err := generateKey()
+	privs, pubs, hashes, err := generateKeySet(count)
 	if err != nil {
 		return err
 	}
 
-	// Print the keys and hash
-	if *verboseFlag {
-		fmt.Printf("Private key: %s\n", priv)
-		fmt.Printf("Advertisement key: %s\n", pub)
-		fmt.Printf("Hashed adv key: %s\n", hash)
+	// Print the keys and hashes
+	if verbose {
+		for i := range privs {
+			fmt.Printf("Private key: %s\n", privs[i])
+			fmt.Printf("Advertisement key: %s\n", pubs[i])
+			fmt.Printf("Hashed adv key: %s\n", hashes[i])
+		}
 	}
 
 	// save keys file
-	if err := saveKeys(name, priv, pub, hash); err != nil {
+	if err := saveKeys(name, privs, pubs, hashes); err != nil {
 		return err
 	}
 
 	// save device file
-	return saveDevice(name, priv)
+	return saveDevice(name, privs)
 }
+
+// defaultKeyCount is how many keys a device gets. With defaultKeyRotation the
+// beacon uses the whole set in one hour and then starts again.
+const defaultKeyCount = 12
+
+// defaultKeyRotation is how long the beacon uses each key.
+const defaultKeyRotation = "5m"
 
 // flashOptions holds the build settings that the flags give.
 type flashOptions struct {
@@ -93,6 +105,7 @@ type flashOptions struct {
 	txPower        string
 	batteryPin     string
 	batteryDivider string
+	rotate         string
 }
 
 // espTargets are the TinyGo targets that use the radio in an ESP32-C3 or
@@ -114,7 +127,7 @@ func isESPTarget(target string) bool {
 }
 
 func flashDevice(name string, target string, opts flashOptions) error {
-	key, err := readKey(name)
+	keys, err := readKeys(name)
 	if err != nil {
 		return err
 	}
@@ -128,7 +141,10 @@ func flashDevice(name string, target string, opts flashOptions) error {
 
 	esp := isESPTarget(target)
 
-	keyVal := fmt.Sprintf("-X main.AdvertisingKey='%s'", key)
+	keyVal := fmt.Sprintf("-X main.AdvertisingKey='%s'", strings.Join(keys, ","))
+	if len(keys) > 1 && opts.rotate != "" {
+		keyVal += fmt.Sprintf(" -X main.KeyRotation=%s", opts.rotate)
+	}
 	if opts.txPower != "" {
 		keyVal += fmt.Sprintf(" -X main.TxPower=%s", opts.txPower)
 		if esp {
@@ -168,26 +184,26 @@ func flashDevice(name string, target string, opts flashOptions) error {
 	return cmd.Run()
 }
 
-func readKey(name string) (string, error) {
-	f, err := os.Open(name + ".keys")
+// readKeys returns every advertisement key in the file of a device, in the
+// order that the beacon uses them.
+func readKeys(name string) ([]string, error) {
+	b, err := os.ReadFile(name + ".keys")
 	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	b := make([]byte, 1024)
-	n, err := f.Read(b)
-	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	lines := strings.Split(string(b[:n]), "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "Advertisement key") {
-			s := strings.Split(line, ":")
-			return strings.TrimLeft(s[1], " "), nil
+	var keys []string
+	for _, line := range strings.Split(string(b), "\n") {
+		if !strings.Contains(line, "Advertisement key") {
+			continue
 		}
+		s := strings.SplitN(line, ":", 2)
+		keys = append(keys, strings.TrimSpace(s[1]))
 	}
 
-	return "", errors.New("key not found")
+	if len(keys) == 0 {
+		return nil, errors.New("key not found")
+	}
+
+	return keys, nil
 }

--- a/cmd/haystack/save.go
+++ b/cmd/haystack/save.go
@@ -8,7 +8,9 @@ import (
 	"text/template"
 )
 
-func saveKeys(name string, priv string, pub string, hash string) error {
+// saveKeys writes one block of three lines for each key, in the order that the
+// beacon uses them.
+func saveKeys(name string, privs []string, pubs []string, hashes []string) error {
 	f, err := os.Create(name + ".keys")
 	if err != nil {
 		return err
@@ -16,9 +18,18 @@ func saveKeys(name string, priv string, pub string, hash string) error {
 
 	defer f.Close()
 
-	f.Write([]byte(fmt.Sprintf("Private key: %s\n", priv)))
-	f.Write([]byte(fmt.Sprintf("Advertisement key: %s\n", pub)))
-	f.Write([]byte(fmt.Sprintf("Hashed adv key: %s\n", hash)))
+	for i := range privs {
+		if i > 0 {
+			if _, err := f.Write([]byte("\n")); err != nil {
+				return err
+			}
+		}
+		block := fmt.Sprintf("Private key: %s\nAdvertisement key: %s\nHashed adv key: %s\n",
+			privs[i], pubs[i], hashes[i])
+		if _, err := f.Write([]byte(block)); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -38,13 +49,25 @@ const deviceTemplate = `[
         "isDeployed": true,
         "colorSpaceName": "kCGColorSpaceExtendedSRGB",
         "usesDerivation": false,
-        "isActive": false,
-        "additionalKeys": []
+        "additionalKeys": [{{range $i, $k := .AdditionalKeys}}{{if $i}},{{end}}
+            "{{$k}}"{{end}}{{if .AdditionalKeys}}
+        {{end}}]
     }
 ]
 `
 
-func saveDevice(name string, priv string) error {
+// deviceData holds the values that deviceTemplate needs.
+type deviceData struct {
+	ID             string
+	Name           string
+	PrivateKey     string
+	AdditionalKeys []string
+}
+
+// saveDevice writes the JSON file for macless-haystack. The first private key
+// is the main key and the others go into additionalKeys, which macless-haystack
+// also fetches reports for.
+func saveDevice(name string, privs []string) error {
 	t, err := template.New("device").Parse(deviceTemplate)
 	if err != nil {
 		return err
@@ -57,16 +80,12 @@ func saveDevice(name string, priv string) error {
 
 	defer f.Close()
 
-	err = t.Execute(f, map[string]string{
-		"ID":         randomInt(1000, 999999),
-		"Name":       name,
-		"PrivateKey": priv,
+	return t.Execute(f, deviceData{
+		ID:             randomInt(1000, 999999),
+		Name:           name,
+		PrivateKey:     privs[0],
+		AdditionalKeys: privs[1:],
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Returns an int >= min, < max

--- a/firmware/keys.go
+++ b/firmware/keys.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+)
+
+// advertisingKeys returns the keys that AdvertisingKey holds. A beacon with
+// more than one key uses them in turn.
+func advertisingKeys() []string {
+	var keys []string
+	for _, key := range strings.Split(AdvertisingKey, ",") {
+		key = strings.TrimSpace(key)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+
+	return keys
+}
+
+// keyData returns the public key data from the base64 encoded string.
+func keyData(key string) ([]byte, error) {
+	val, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+	if len(val) != 28 {
+		return nil, errors.New("public key must be 28 bytes long")
+	}
+
+	return val, nil
+}
+
+// rotationInterval returns how long the beacon uses each key. It returns false
+// if KeyRotation is empty or holds a bad value, which keeps one key for ever.
+func rotationInterval() (time.Duration, bool) {
+	if KeyRotation == "" {
+		return 0, false
+	}
+
+	d, err := time.ParseDuration(KeyRotation)
+	if err != nil {
+		println("bad KeyRotation value:", KeyRotation)
+		return 0, false
+	}
+	if d <= 0 {
+		println("KeyRotation must be more than zero:", KeyRotation)
+		return 0, false
+	}
+
+	return d, true
+}
+
+// sleepTime returns the time to the nearest deadline. A deadline with a zero
+// value is not in use. It returns an hour if no deadline is in use.
+func sleepTime(now time.Time, deadlines ...time.Time) time.Duration {
+	wait := time.Hour
+	for _, deadline := range deadlines {
+		if deadline.IsZero() {
+			continue
+		}
+		if d := deadline.Sub(now); d < wait {
+			wait = d
+		}
+	}
+
+	if wait < time.Millisecond {
+		return time.Millisecond
+	}
+
+	return wait
+}

--- a/firmware/keys_test.go
+++ b/firmware/keys_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAdvertisingKeys checks the list of keys that AdvertisingKey gives.
+func TestAdvertisingKeys(t *testing.T) {
+	// The build gives this value, so keep it and put it back.
+	old := AdvertisingKey
+	defer func() { AdvertisingKey = old }()
+
+	tests := []struct {
+		key  string
+		want []string
+	}{
+		{"AAA", []string{"AAA"}},
+		{"AAA,BBB", []string{"AAA", "BBB"}},
+		{" AAA , BBB ", []string{"AAA", "BBB"}},
+		{"AAA,BBB,CCC", []string{"AAA", "BBB", "CCC"}},
+		// An empty part is not a key.
+		{"AAA,,BBB", []string{"AAA", "BBB"}},
+		{"AAA,", []string{"AAA"}},
+		{"", nil},
+		{",", nil},
+	}
+
+	for _, tc := range tests {
+		AdvertisingKey = tc.key
+		got := advertisingKeys()
+		if len(got) != len(tc.want) {
+			t.Errorf("AdvertisingKey=%q: got %d keys, want %d", tc.key, len(got), len(tc.want))
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("AdvertisingKey=%q: key %d is %q, want %q", tc.key, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// TestKeyData checks that only a 28 byte base64 key is usable.
+func TestKeyData(t *testing.T) {
+	good := base64.StdEncoding.EncodeToString(make([]byte, 28))
+	short := base64.StdEncoding.EncodeToString(make([]byte, 27))
+
+	tests := []struct {
+		key    string
+		wantOK bool
+	}{
+		{good, true},
+		{short, false},
+		{"", false},
+		{"not base64!", false},
+	}
+
+	for _, tc := range tests {
+		val, err := keyData(tc.key)
+		if (err == nil) != tc.wantOK {
+			t.Errorf("keyData(%q): got error %v, want ok %v", tc.key, err, tc.wantOK)
+			continue
+		}
+		if tc.wantOK && len(val) != 28 {
+			t.Errorf("keyData(%q): got %d bytes, want 28", tc.key, len(val))
+		}
+	}
+}
+
+// TestRotationInterval checks the interval that KeyRotation gives.
+func TestRotationInterval(t *testing.T) {
+	// The command line gives this value, so keep it and put it back.
+	old := KeyRotation
+	defer func() { KeyRotation = old }()
+
+	tests := []struct {
+		rotation string
+		want     time.Duration
+		wantOK   bool
+	}{
+		{"5m", 5 * time.Minute, true},
+		{"30s", 30 * time.Second, true},
+		{"1h30m", 90 * time.Minute, true},
+		// No value keeps the first key for ever.
+		{"", 0, false},
+		{"0s", 0, false},
+		{"-5m", 0, false},
+		{"junk", 0, false},
+		{"5", 0, false},
+	}
+
+	for _, tc := range tests {
+		KeyRotation = tc.rotation
+		got, ok := rotationInterval()
+		if ok != tc.wantOK || got != tc.want {
+			t.Errorf("KeyRotation=%q: got %v %v, want %v %v", tc.rotation, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestSleepTime checks the wait to the nearest deadline.
+func TestSleepTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		deadlines []time.Time
+		want      time.Duration
+	}{
+		{"no deadline", nil, time.Hour},
+		{"zero values only", []time.Time{{}, {}}, time.Hour},
+		{"one deadline", []time.Time{now.Add(5 * time.Minute)}, 5 * time.Minute},
+		{"nearest of two", []time.Time{now.Add(15 * time.Minute), now.Add(5 * time.Minute)}, 5 * time.Minute},
+		{"one in use", []time.Time{{}, now.Add(20 * time.Second)}, 20 * time.Second},
+		// A deadline that has passed must not make a wait of zero.
+		{"passed", []time.Time{now.Add(-time.Minute)}, time.Millisecond},
+		// A deadline that is further away than an hour still waits an hour.
+		{"far away", []time.Time{now.Add(3 * time.Hour)}, time.Hour},
+	}
+
+	for _, tc := range tests {
+		if got := sleepTime(now, tc.deadlines...); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRotationText checks the message that the beacon prints at start up.
+func TestRotationText(t *testing.T) {
+	old := KeyRotation
+	defer func() { KeyRotation = old }()
+
+	KeyRotation = "5m"
+	if got := rotationText(false); got != "off" {
+		t.Errorf("rotationText(false): got %q, want %q", got, "off")
+	}
+	if got := rotationText(true); !strings.Contains(got, "5m") {
+		t.Errorf("rotationText(true): got %q, want %q", got, "5m")
+	}
+}

--- a/firmware/main.go
+++ b/firmware/main.go
@@ -5,15 +5,18 @@
 // tinygo flash -target nano-rp2040 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
 // tinygo flash -target xiao-esp32c3 -ldflags="-X main.AdvertisingKey='SGVsbG8sIFdvcmxkIQ=='" .
 //
+// For a beacon that changes its key, give more keys, separated by commas, and the
+// time on each key:
+// -ldflags="-X main.AdvertisingKey='KEY1,KEY2' -X main.KeyRotation=5m"
+//
 // For a device on a battery, see the power settings in README.md.
 //
 // For Linux:
 // go run . SGVsbG8sIFdvcmxkIQ==
+// go run . KEY1,KEY2 5m
 package main
 
 import (
-	"encoding/base64"
-	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -37,11 +40,22 @@ func main() {
 	// wait for USB serial to be available
 	time.Sleep(2 * time.Second)
 
-	key, err := getKeyData()
+	keys := advertisingKeys()
+	if len(keys) == 0 {
+		fail("no advertising key")
+	}
+	key, err := keyData(keys[0])
 	if err != nil {
 		fail("failed to get key data: " + err.Error())
 	}
-	println("key is", AdvertisingKey, "(", len(key), "bytes)")
+
+	// A beacon with one key keeps it for ever, so the interval has no use.
+	rotation, rotating := rotationInterval()
+	if len(keys) == 1 {
+		rotating = false
+	}
+	println("keys are", strconv.Itoa(len(keys)), "and rotation is", rotationText(rotating))
+	println("key 0 is", keys[0], "(", len(key), "bytes)")
 
 	// This first reading must stay before adapter.Enable below. On an ESP32 it
 	// starts the ADC, which must not happen while the radio runs.
@@ -80,7 +94,7 @@ func main() {
 
 	// Set the address to the first 6 bytes of the public key. This call must
 	// stay between Enable and Start, because each one needs it.
-	adapter.SetRandomAddress(bluetooth.MAC{key[5], key[4], key[3], key[2], key[1], key[0] | 0xC0})
+	setAddress(key)
 
 	println("configure advertising...")
 	adv := adapter.DefaultAdvertisement()
@@ -102,51 +116,101 @@ func main() {
 	println("FindMy device using", address.MAC.String())
 
 	// A Nordic radio advertises on its own from here, so the CPU only wakes to
-	// read the battery. A radio on the HCI path keeps a poll loop running.
+	// change the key or to read the battery. A radio on the HCI path keeps a
+	// poll loop running.
+	var nextBattery, nextRotation time.Time
+	if hasBattery {
+		nextBattery = time.Now().Add(batteryCheckInterval)
+	}
+	if rotating {
+		nextRotation = time.Now().Add(rotation)
+	}
+
+	index := 0
 	for {
-		if !hasBattery {
-			time.Sleep(time.Hour)
-			continue
+		time.Sleep(sleepTime(time.Now(), nextBattery, nextRotation))
+		now := time.Now()
+
+		if !nextRotation.IsZero() && !now.Before(nextRotation) {
+			nextRotation = now.Add(rotation)
+			index = (index + 1) % len(keys)
+
+			// A bad key must not stop the beacon, so it keeps the key it has
+			// and tries the next one later.
+			next, err := keyData(keys[index])
+			if err != nil {
+				println("bad key", strconv.Itoa(index), err.Error())
+			} else {
+				key = next
+				println("key", strconv.Itoa(index), "is", keys[index])
+				advertising = restartAdvertising(adv, &opts, key, status, advertising)
+			}
 		}
 
-		time.Sleep(batteryCheckInterval)
+		if !nextBattery.IsZero() && !now.Before(nextBattery) {
+			nextBattery = now.Add(batteryCheckInterval)
 
-		millivolts, ok := readBatteryMillivolts()
-		if !ok {
-			continue
-		}
-		newStatus := batteryStatus(millivolts)
-		if newStatus == status {
-			continue
-		}
-		status = newStatus
-		println("battery is", strconv.Itoa(int(millivolts)), "mV,", findmy.BatteryStatus(status))
-
-		// The BLE stack refuses a new set of parameters while it advertises, so
-		// stop before the payload changes.
-		//
-		// Stop must never run if Start failed. On the HCI path Stop waits for
-		// the poll loop that Start makes, and it waits for ever if none runs.
-		if advertising {
-			if err := adv.Stop(); err != nil {
-				println("cannot stop adv:", err.Error())
+			millivolts, ok := readBatteryMillivolts()
+			if !ok {
 				continue
 			}
-			advertising = false
-		}
+			newStatus := batteryStatus(millivolts)
+			if newStatus == status {
+				continue
+			}
+			status = newStatus
+			println("battery is", strconv.Itoa(int(millivolts)), "mV,", findmy.BatteryStatus(status))
 
-		// A failure here must not stop the device being found, so it goes on
-		// and always tries to advertise again.
-		opts.ManufacturerData = []bluetooth.ManufacturerDataElement{findmy.NewDataWithStatus(key, status)}
-		if err := adv.Configure(opts); err != nil {
-			println("cannot config adv:", err.Error())
+			advertising = restartAdvertising(adv, &opts, key, status, advertising)
 		}
-		if err := adv.Start(); err != nil {
-			println("cannot start adv:", err.Error())
-			continue
-		}
-		advertising = true
 	}
+}
+
+// setAddress uses the first 6 bytes of the key as the BLE address, so the
+// address changes with the key.
+func setAddress(key []byte) {
+	adapter.SetRandomAddress(bluetooth.MAC{key[5], key[4], key[3], key[2], key[1], key[0] | 0xC0})
+}
+
+// restartAdvertising puts the key and the status in the advertisement, then
+// starts it again. It returns the new state of the advertisement.
+//
+// A failure here must not stop the device being found, so it goes on and always
+// tries to advertise again.
+func restartAdvertising(adv *bluetooth.Advertisement, opts *bluetooth.AdvertisementOptions, key []byte, status byte, advertising bool) bool {
+	// The BLE stack refuses a new set of parameters while it advertises, so
+	// stop before the payload changes.
+	//
+	// Stop must never run if Start failed. On the HCI path Stop waits for the
+	// poll loop that Start makes, and it waits for ever if none runs.
+	if advertising {
+		if err := adv.Stop(); err != nil {
+			println("cannot stop adv:", err.Error())
+			return true
+		}
+	}
+
+	setAddress(key)
+
+	opts.ManufacturerData = []bluetooth.ManufacturerDataElement{findmy.NewDataWithStatus(key, status)}
+	if err := adv.Configure(*opts); err != nil {
+		println("cannot config adv:", err.Error())
+	}
+	if err := adv.Start(); err != nil {
+		println("cannot start adv:", err.Error())
+		return false
+	}
+
+	return true
+}
+
+// rotationText tells if the beacon rotates its keys.
+func rotationText(rotating bool) string {
+	if !rotating {
+		return "off"
+	}
+
+	return KeyRotation
 }
 
 // dcdcEnabled reports if the DC/DC regulator must be turned on. The regulator
@@ -183,19 +247,6 @@ func txPower() (int8, bool) {
 		return 0, false
 	}
 	return int8(dbm), true
-}
-
-// getKeyData returns the public key data from the base64 encoded string.
-func getKeyData() ([]byte, error) {
-	val, err := base64.StdEncoding.DecodeString(AdvertisingKey)
-	if err != nil {
-		return nil, err
-	}
-	if len(val) != 28 {
-		return nil, errors.New("public key must be 28 bytes long")
-	}
-
-	return val, nil
 }
 
 // must calls a function and fails if an error occurs.

--- a/firmware/mcu.go
+++ b/firmware/mcu.go
@@ -2,7 +2,8 @@
 
 package main
 
-// AdvertisingKey is the public key of the device. Must be base64 encoded.
+// AdvertisingKey holds the public keys of the device, separated by commas.
+// Must be base64 encoded.
 var AdvertisingKey string
 
 // TxPower is the radio transmit power in dBm. An empty value keeps the default
@@ -25,3 +26,8 @@ var BatteryPin string
 // BatteryDivider is the ratio of the battery divider, such as "1510/510". A
 // single number is a ratio to 1. An empty value stops the reading.
 var BatteryDivider string
+
+// KeyRotation is how long the beacon uses each key, such as "5m". An empty
+// value keeps the first key for ever. Set it with
+// -ldflags "-X main.KeyRotation=5m".
+var KeyRotation string

--- a/firmware/os.go
+++ b/firmware/os.go
@@ -4,8 +4,23 @@ package main
 
 import "os"
 
-// AdvertisingKey is the public key of the device. Must be base64 encoded.
+// AdvertisingKey holds the public keys of the device, separated by commas.
+// Must be base64 encoded.
 var AdvertisingKey = os.Args[1]
+
+// KeyRotation is how long the beacon uses each key, such as "5m". It comes from
+// the second argument, and an empty value keeps the first key for ever.
+var KeyRotation = argument(2)
+
+// argument returns the argument at the index, or an empty string if the command
+// line does not have it.
+func argument(index int) string {
+	if len(os.Args) <= index {
+		return ""
+	}
+
+	return os.Args[index]
+}
 
 // TxPower is the radio transmit power in dBm. An operating system does not give
 // this control, so it stays empty here.


### PR DESCRIPTION
## What this does

A beacon sent the same key for its whole life, so anybody who scans could follow the
device. A device now gets a set of keys, and the beacon uses them one after the other. The
Bluetooth address changes with the key, because the address is the first 6 bytes of the
key.

`haystack keys DEVICENAME` makes 12 keys, and the beacon uses each key for 5 minutes, so
the set lasts one hour and then starts again. Two new flags change this:

```shell
haystack -keys=24 keys DEVICENAME
haystack -rotate=15m flash DEVICENAME xiao-ble
```

`-keys=1` gives the behavior of the older versions, which is one key for ever.

## How it works

- `generateKeySet` makes the keys. It asks again when the hash of a key holds a `/`,
  because macless-haystack puts that value in a URL path. About half of all keys fail this
  test, so a set of 12 needs the retry.
- The keys file holds one block of three lines for each key. The labels do not change and
  the first block is the first key, so an older file with one key still works, and so does
  `flash.sh`.
- The JSON file puts the first private key in `privateKey` and the others in
  `additionalKeys`. macless-haystack fetches reports for all of them together, so the web
  UI shows one device with one history.
- `flash` gives the keys to the firmware in `main.AdvertisingKey`, separated by commas,
  and the time on each key in the new `main.KeyRotation`.
- The firmware holds the keys as base64 text and decodes only the key it uses, so it never
  holds 12 decoded keys at one time. The main loop now waits for the nearer of two
  deadlines, one for the key and one for the battery, and one helper stops, configures and
  starts the advertisement for both.

A device that gets a new set of keys must have its JSON file imported into
macless-haystack again.

## Tests

- New unit tests for the key list, the key data, the interval, the wait to the nearest
  deadline, the key set, the keys file round trip and the JSON file.
- `gofmt`, `go vet` and `go test` pass in all three modules.
- `tinygo build` passes for `xiao-ble` and `xiao-esp32c3` with 2 keys and with 12 keys. A
  set of 12 keys costs about 1 KB of flash.

## Tested on hardware

Flashed to a Seeed XIAO nRF52840 with `haystack -rotate=1m flash demo xiao-ble`, with a
set of 12 keys. The console showed the key change once a minute, for seven rotations, and
never printed a stop or a start failure, so the SoftDevice accepts the new address after
`Stop`:

```
key 5 is QpLUDvgUiJVP2MzAnLHQ0L4q36HiiD2FYagYUA==
key 6 is hgob3Pw7AQeFFPKaunYRqbVNiK06RospJ1cBnA==
key 7 is v0Htr51O2WUFIrVGRcLiLy3yYCBfJYFh2Y2iJA==
```

`haystack scan` at the same time showed the same keys in the air, each one with its own
address:

```
key 4  addr DC:1F:3A:A2:1F:13
key 5  addr C2:92:D4:0E:F8:14
key 6  addr C6:0A:1B:DC:FC:3B
key 7  addr FF:41:ED:AF:9D:4E
```

The battery status still reads correctly and the payload still parses.

Reports for more than one key in macless-haystack are not tested, because that needs an
endpoint and an iPhone in range.
