### PR TITLE
haystack: add a version to the tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ haystack version
 Returns the version of the tool, with the revision of the build if it has one:
 
 ```
-haystack 0.1.0 (7180716)
+haystack 0.2.0-dev (7180716)
 ```
 
 ### Scanning for local devices

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ go install github.com/hybridgroup/go-haystack/cmd/haystack@latest
 
 ## How to use
 
+### Showing the version
+
+```shell
+haystack version
+```
+
+Returns the version of the tool, with the revision of the build if it has one:
+
+```
+haystack 0.1.0 (7180716)
+```
+
 ### Scanning for local devices
 
 ```shell

--- a/cmd/haystack/main.go
+++ b/cmd/haystack/main.go
@@ -9,7 +9,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/hybridgroup/go-haystack"
 )
+
+// usage names the subcommands of the tool.
+const usage = "subcommand required. valid subcommands are 'keys' 'flash' 'scan' 'version'"
 
 func main() {
 	verboseFlag := flag.Bool("v", false, "enable verbose mode")
@@ -24,7 +29,7 @@ func main() {
 
 	args := flag.Args()
 	if len(args) < 1 {
-		fmt.Println("subcommand required. valid subcommands are 'keys' 'flash' 'scan'")
+		fmt.Println(usage)
 		return
 	}
 
@@ -58,8 +63,10 @@ func main() {
 		if err := scanDevices(verboseFlag); err != nil {
 			fmt.Println("failed to scan devices:", err)
 		}
+	case "version":
+		fmt.Println("haystack", haystack.VersionString())
 	default:
-		fmt.Println("subcommand required. valid subcommands are 'keys' 'flash' 'scan'")
+		fmt.Println(usage)
 		return
 	}
 }

--- a/haystack.go
+++ b/haystack.go
@@ -1,1 +1,38 @@
 package haystack
+
+import "runtime/debug"
+
+// Version is the release version of go-haystack.
+const Version = "0.1.0"
+
+// VersionString returns the version with the VCS revision of the build, if the
+// binary has one.
+func VersionString() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return Version
+	}
+
+	var rev string
+	var dirty bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			dirty = s.Value == "true"
+		}
+	}
+
+	if rev == "" {
+		return Version
+	}
+	if len(rev) > 7 {
+		rev = rev[:7]
+	}
+	if dirty {
+		rev += "-dirty"
+	}
+
+	return Version + " (" + rev + ")"
+}

--- a/haystack.go
+++ b/haystack.go
@@ -3,7 +3,7 @@ package haystack
 import "runtime/debug"
 
 // Version is the release version of go-haystack.
-const Version = "0.1.0"
+const Version = "0.2.0-dev"
 
 // VersionString returns the version with the VCS revision of the build, if the
 // binary has one.


### PR DESCRIPTION
The `haystack` tool had no version, so a user could not tell which build was installed.

## Changes

- `haystack.go`: the root package now has `Version` and `VersionString()`. Go code that imports the module can read the version.
- `cmd/haystack/main.go`: a `version` subcommand prints the version. The usage line is now one constant, and it names the new subcommand.
- `README.md`: documents the subcommand.

`VersionString()` adds the short VCS revision from `runtime/debug.ReadBuildInfo`, with a `-dirty` marker for a work tree with changes. It returns the version alone if the binary has no build info.

```
$ haystack version
haystack 0.1.0 (7180716-dirty)
```

Bump the `Version` constant by hand at each release.