### PR TITLE
ci: add build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  tinygo:
+    name: tinygo ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {dir: ./firmware, target: xiao-ble}
+          - {dir: ./firmware, target: nicenano}
+          - {dir: ./firmware, target: feather-nrf52840}
+          - {dir: ./firmware, target: xiao-esp32c3}
+          - {dir: ./firmware, target: xiao-esp32s3}
+          - {dir: ./firmware, target: m5stamp-c3}
+          - {dir: ./firmware, target: pico-w}
+          - {dir: ./tinyscan, target: badger2040-w, flags: -stack-size 8kb}
+          - {dir: ./tinyscan, target: clue, flags: -stack-size 8kb}
+          - {dir: ./tinyscan, target: pybadge, flags: -stack-size 8kb}
+          - {dir: ./tinyscan, target: pyportal, flags: -stack-size 8kb}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: acifani/setup-tinygo@v2
+        with:
+          tinygo-version: '0.42.0'
+      - run: tinygo build -o /dev/null -size short ${{ matrix.flags }} -target=${{ matrix.target }} ${{ matrix.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - {os: ubuntu-latest, packages: ./...}
+          - {os: windows-latest, packages: ./...}
+          # The firmware package advertises, which the bluetooth package does not
+          # do on CoreBluetooth, so macOS only gets the other packages.
+          - {os: macos-latest, packages: . ./cmd/... ./lib/...}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
-      - run: go build ./...
-      - run: go vet ./...
-      - run: go test ./...
+      - run: go build ${{ matrix.packages }}
+      - run: go vet ${{ matrix.packages }}
+      - run: go test ${{ matrix.packages }}
 
   tinygo:
     name: tinygo ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-haystack
 
+[![CI](https://github.com/hybridgroup/go-haystack/actions/workflows/ci.yml/badge.svg)](https://github.com/hybridgroup/go-haystack/actions/workflows/ci.yml)
+
 ![Go Haystack gopher](./images/go-haystack.png)
 
 Go Haystack lets you track personal Bluetooth devices via Apple's massive ["Find My"](https://developer.apple.com/find-my/) network.
@@ -204,3 +206,19 @@ endpoint for more keys at each refresh. A set of 24 keys with `-rotate=1h` cover
 The rotation needs both parts, so a device that already has a key file with one key keeps
 that one key until you make a new set. A device that gets a new set also needs its JSON
 file imported into macless-haystack again.
+
+## How to test
+
+The unit tests run on the host, so they need no hardware:
+
+```shell
+go test ./...
+```
+
+The firmware and TinyScan code only compiles for a microcontroller. To check it, build one
+of the targets:
+
+```shell
+tinygo build -o /dev/null -target=xiao-ble ./firmware
+tinygo build -o /dev/null -stack-size 8kb -target=clue ./tinyscan
+```

--- a/cmd/haystack/keys.go
+++ b/cmd/haystack/keys.go
@@ -12,6 +12,9 @@ import (
 
 var errInvalidHash = errors.New("Hash contains '/'")
 
+// keySize is the size of a P-224 key in bytes.
+const keySize = 28
+
 func generateKey() (string, string, string, error) {
 	// Generate ECDSA private key using P-224 curve
 	pk, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
@@ -19,19 +22,15 @@ func generateKey() (string, string, string, error) {
 		return "", "", "", err
 	}
 
-	// Extract the raw private key bytes
-	privateKeyBytes := pk.D.Bytes()
-
-	// Ensure the private key is 28 bytes long (P-224 curve)
-	if len(privateKeyBytes) != 28 {
-		return "", "", "", errors.New("Private key is not 28 bytes long")
-	}
+	// Extract the raw private key bytes. FillBytes keeps the leading zeros,
+	// which Bytes removes, so the key is always the full size of the curve.
+	privateKeyBytes := pk.D.FillBytes(make([]byte, keySize))
 
 	// Encode the raw private key to Base64
 	privateKeyBase64 := base64.StdEncoding.EncodeToString(privateKeyBytes)
 
 	// extract raw public key bytes
-	publicKeyBytes := pk.PublicKey.X.Bytes()
+	publicKeyBytes := pk.PublicKey.X.FillBytes(make([]byte, keySize))
 
 	// Encode the public key to Base64
 	publicKeyBase64 := base64.StdEncoding.EncodeToString(publicKeyBytes)

--- a/cmd/haystack/keys_test.go
+++ b/cmd/haystack/keys_test.go
@@ -38,6 +38,12 @@ func TestGenerateKeySet(t *testing.T) {
 			if err != nil || len(val) != 28 {
 				t.Errorf("count %d: adv key %d is %d bytes, %v", count, i, len(val), err)
 			}
+
+			// A key with a leading zero must keep the full size.
+			val, err = base64.StdEncoding.DecodeString(privs[i])
+			if err != nil || len(val) != 28 {
+				t.Errorf("count %d: private key %d is %d bytes, %v", count, i, len(val), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
The repository had no CI, so no change was checked before a merge.

This adds a GitHub Actions workflow with two jobs.

The `test` job runs `go build`, `go vet` and `go test` on Linux, macOS and Windows. All
three hosts are necessary, because the Bluetooth backend is different on each one. A cross
build for macOS is not enough, because the CoreBluetooth backend needs cgo. On macOS the
job skips the `firmware` package, because the bluetooth package does not advertise on
CoreBluetooth.

The `tinygo` job builds the `firmware` and `tinyscan` packages with TinyGo 0.42.0. Every
file in `tinyscan` has a build tag for a microcontroller, and the same is true for many
files in `firmware`, so a host build never compiles them. The target list covers each
build tag branch:

- `xiao-ble`, which also covers the SoftDevice power code
- `nicenano`
- `feather-nrf52840`
- `xiao-esp32c3`, `xiao-esp32s3`, `m5stamp-c3`
- `pico-w`, which also covers the other battery and power code
- `badger2040-w`, `clue`, `pybadge`, `pyportal` for `tinyscan`

The first run found a fault in the key generation. `big.Int.Bytes` removes the leading zero
bytes, so about one key in 256 was 27 bytes and `haystack keys` stopped with the error
"Private key is not 28 bytes long". The advertisement key had the same fault. `FillBytes`
now keeps both keys at the full size of the P-224 curve, and the test also checks the size
of the private key. A run of 6400 keys gives no error.

The README gets a status badge and a section that tells how to run the tests.