### PR TITLE
firmware: set the battery thresholds for the cell type

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ This will use TinyGo to compile the firmware using your keys, and then flash it 
 For a device on a battery, add `-battery`, which turns the serial port off. Add
 `-txpower` to lower the radio transmit power, which saves more current but shortens
 the range. On an ESP32-C3 or ESP32-S3 board, add `-batterypin` and `-batterydivider` to
-read the battery. Add `-rotate` for a different time on each key. All flags go before the
-subcommand. See [Battery Powered Beacons](./firmware/README.md#battery-powered-beacons) and
+read the battery. Add `-batterytype` for a cell that is not a LiPo, such as a CR2032, or
+`-batterythresholds` for the voltages of any other cell. Add `-rotate` for a different
+time on each key. All flags go before the subcommand. See [Battery Powered Beacons](./firmware/README.md#battery-powered-beacons) and
 [Rotating Keys](#rotating-keys).
 
 ```shell

--- a/cmd/haystack/main.go
+++ b/cmd/haystack/main.go
@@ -23,6 +23,8 @@ func main() {
 	dcdc0Flag := flag.Bool("dcdc0", false, "turn the DC/DC converter of the VDDH stage on. Needs a board powered through VDDH, and often gains nothing from a battery")
 	batteryPinFlag := flag.String("batterypin", "", "GPIO number that reads a battery divider, for example 2. Only an ESP32-C3 or ESP32-S3 board needs it")
 	batteryDividerFlag := flag.String("batterydivider", "", "ratio of the battery divider, for example 2/1. A single number is a ratio to 1")
+	batteryTypeFlag := flag.String("batterytype", "", "cell that the beacon uses, one of lipo, cr2032, cr1220 or aa-alkaline. Empty is lipo")
+	batteryThresholdsFlag := flag.String("batterythresholds", "", "full, medium and low battery voltages in millivolts, for example 2900/2750/2600. It wins over -batterytype")
 	keysFlag := flag.Int("keys", defaultKeyCount, "how many keys to generate for a device, which the beacon then uses in turn")
 	rotateFlag := flag.String("rotate", defaultKeyRotation, "how long the beacon uses each key, for example 5m. An empty value stops the rotation")
 	flag.Parse()
@@ -48,13 +50,15 @@ func main() {
 			return
 		}
 		opts := flashOptions{
-			verbose:        *verboseFlag,
-			battery:        *batteryFlag,
-			dcdc0:          *dcdc0Flag,
-			txPower:        *txPowerFlag,
-			batteryPin:     *batteryPinFlag,
-			batteryDivider: *batteryDividerFlag,
-			rotate:         *rotateFlag,
+			verbose:           *verboseFlag,
+			battery:           *batteryFlag,
+			dcdc0:             *dcdc0Flag,
+			txPower:           *txPowerFlag,
+			batteryPin:        *batteryPinFlag,
+			batteryDivider:    *batteryDividerFlag,
+			batteryType:       *batteryTypeFlag,
+			batteryThresholds: *batteryThresholdsFlag,
+			rotate:            *rotateFlag,
 		}
 		if err := flashDevice(args[1], args[2], opts); err != nil {
 			fmt.Println("failed to flash device:", err)
@@ -112,7 +116,11 @@ type flashOptions struct {
 	txPower        string
 	batteryPin     string
 	batteryDivider string
-	rotate         string
+	// batteryType and batteryThresholds set the voltages that give the battery
+	// status. batteryThresholds wins over batteryType.
+	batteryType       string
+	batteryThresholds string
+	rotate            string
 }
 
 // espTargets are the TinyGo targets that use the radio in an ESP32-C3 or
@@ -166,6 +174,12 @@ func flashDevice(name string, target string, opts flashOptions) error {
 	}
 	if opts.batteryDivider != "" {
 		keyVal += fmt.Sprintf(" -X main.BatteryDivider=%s", opts.batteryDivider)
+	}
+	if opts.batteryType != "" {
+		keyVal += fmt.Sprintf(" -X main.BatteryType=%s", opts.batteryType)
+	}
+	if opts.batteryThresholds != "" {
+		keyVal += fmt.Sprintf(" -X main.BatteryThresholds=%s", opts.batteryThresholds)
 	}
 
 	args := []string{"flash", "-target", target}

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -128,10 +128,51 @@ The ADC on these chips has no calibration, so the voltage can be several percent
 and the thresholds are only 200 mV apart. To correct this, measure the battery with a
 multimeter one time, then change `BatteryDivider` until the message agrees with the meter.
 
-The thresholds suit a single cell LiPo, which is full at 4200 mV and empty at about
-3300 mV. They are the `battery...Millivolts` constants in
-[firmware/battery.go](./battery.go). A device with a different cell, such as a
-coin cell, needs different values there.
+#### The cell type
+
+The default thresholds suit a single cell LiPo, which is full at 4200 mV and empty at
+about 3300 mV. A 3 V coin cell never gets above 3500 mV, so it reports a critical
+battery for its whole life with these values. Give the cell type instead:
+
+```shell
+haystack -batterytype=cr2032 flash DEVICENAME xiao-ble
+```
+
+| Type | Full | Medium | Low |
+| --- | --- | --- | --- |
+| `lipo` (the default) | 3900 mV | 3700 mV | 3500 mV |
+| `cr2032` | 2900 mV | 2750 mV | 2600 mV |
+| `cr1220` | 2950 mV | 2800 mV | 2650 mV |
+| `aa-alkaline` | 2800 mV | 2500 mV | 2200 mV |
+
+The thresholds come from the discharge curve of the cell and not from its capacity in
+mAh. A CR2032 and a CR1220 are the same lithium chemistry and have almost the same
+curve. The CR1220 has a much smaller capacity, so it is empty much sooner, but the
+voltage at which it is empty is nearly the same. Its internal resistance is higher, so
+it sags more when the radio transmits, and its thresholds are 50 mV higher for this
+reason. `aa-alkaline` is two alkaline cells in series, AA or AAA.
+
+For a cell that is not in the table, give the three voltages in millivolts. They are the
+full, medium and low values in that order, and each one must be lower than the one
+before:
+
+```shell
+haystack -batterythresholds=2900/2750/2600 flash DEVICENAME xiao-ble
+```
+
+The same values with `tinygo` alone:
+
+```
+-ldflags="-X main.AdvertisingKey='$ADVKEY' -X main.BatteryType=cr2032"
+-ldflags="-X main.AdvertisingKey='$ADVKEY' -X main.BatteryThresholds=2900/2750/2600"
+```
+
+`BatteryThresholds` wins over `BatteryType`. The firmware prints a message and uses the
+LiPo values if a value is not usable, so a wrong value cannot stop the beacon.
+
+A 3 V coin cell on an ESP32-C3 or ESP32-S3 board often needs no divider, because it is
+already below the 2500 mV that the ADC reads well. Give `-batterydivider=1/1` to read the
+pin directly.
 
 
 ## Technical details

--- a/firmware/battery.go
+++ b/firmware/battery.go
@@ -2,14 +2,28 @@ package main
 
 import "github.com/hybridgroup/go-haystack/lib/findmy"
 
-// Thresholds in millivolts for a single cell LiPo battery, which is full at
-// 4200 mV and empty at about 3300 mV. A device that uses a different cell needs
-// different values here.
-const (
-	batteryFullMillivolts   = 3900
-	batteryMediumMillivolts = 3700
-	batteryLowMillivolts    = 3500
-)
+// batteryLimits holds the thresholds in millivolts that give the status of a
+// battery.
+type batteryLimits struct {
+	full, medium, low uint16
+}
+
+// batteryProfiles gives the thresholds for each cell type. The coin cell values
+// come from the Energizer CR2032 and CR1220 datasheets, and the alkaline values
+// are for two Energizer E91 cells in series.
+// https://data.energizer.com/pdfs/cr2032.pdf
+// https://data.energizer.com/pdfs/cr1220.pdf
+// https://data.energizer.com/pdfs/e91.pdf
+var batteryProfiles = map[string]batteryLimits{
+	"lipo":        {3900, 3700, 3500},
+	"cr2032":      {2900, 2750, 2600},
+	"cr1220":      {2950, 2800, 2650},
+	"aa-alkaline": {2800, 2500, 2200},
+}
+
+// defaultBatteryType is the cell that the firmware uses when BatteryType is
+// empty.
+const defaultBatteryType = "lipo"
 
 // batteryMillivolts converts a raw ADC reading to the battery voltage. raw is
 // the 16 bit value that the ADC returns, reference is the full scale of the ADC
@@ -21,13 +35,13 @@ func batteryMillivolts(raw, reference, numerator, denominator uint32) uint16 {
 }
 
 // batteryStatus returns the FindMy status byte for a battery voltage.
-func batteryStatus(millivolts uint16) byte {
+func batteryStatus(millivolts uint16, limits batteryLimits) byte {
 	switch {
-	case millivolts >= batteryFullMillivolts:
+	case millivolts >= limits.full:
 		return findmy.StatusBatteryFull
-	case millivolts >= batteryMediumMillivolts:
+	case millivolts >= limits.medium:
 		return findmy.StatusBatteryMedium
-	case millivolts >= batteryLowMillivolts:
+	case millivolts >= limits.low:
 		return findmy.StatusBatteryLow
 	default:
 		return findmy.StatusBatteryCritical

--- a/firmware/battery_config.go
+++ b/firmware/battery_config.go
@@ -53,3 +53,60 @@ func parseDivider(s string) (uint32, uint32, bool) {
 
 	return uint32(num), uint32(den), true
 }
+
+// batteryThresholds returns the thresholds that BatteryThresholds and
+// BatteryType give. It returns the default profile unless a value is usable.
+func batteryThresholds() batteryLimits {
+	fallback := batteryProfiles[defaultBatteryType]
+
+	if BatteryThresholds != "" {
+		limits, ok := parseThresholds(BatteryThresholds)
+		if !ok {
+			println("bad BatteryThresholds value:", BatteryThresholds)
+			return fallback
+		}
+		return limits
+	}
+
+	if BatteryType == "" {
+		return fallback
+	}
+
+	limits, ok := batteryProfiles[BatteryType]
+	if !ok {
+		println("bad BatteryType value:", BatteryType)
+		return fallback
+	}
+
+	return limits
+}
+
+// parseThresholds reads three thresholds in millivolts, such as
+// "2900/2750/2600", which are the full, medium and low values in that order.
+func parseThresholds(s string) (batteryLimits, bool) {
+	var limits batteryLimits
+
+	parts := strings.Split(s, "/")
+	if len(parts) != 3 {
+		return limits, false
+	}
+
+	values := [3]uint16{}
+	for i, part := range parts {
+		v, err := strconv.ParseUint(part, 10, 16)
+		if err != nil {
+			return limits, false
+		}
+		values[i] = uint16(v)
+	}
+
+	// A lower status must need a lower voltage, or the switch in batteryStatus
+	// can never reach it.
+	if !(values[0] > values[1] && values[1] > values[2] && values[2] > 0) {
+		return limits, false
+	}
+
+	limits.full, limits.medium, limits.low = values[0], values[1], values[2]
+
+	return limits, true
+}

--- a/firmware/main.go
+++ b/firmware/main.go
@@ -59,10 +59,11 @@ func main() {
 
 	// This first reading must stay before adapter.Enable below. On an ESP32 it
 	// starts the ADC, which must not happen while the radio runs.
+	limits := batteryThresholds()
 	millivolts, hasBattery := readBatteryMillivolts()
 	status := byte(findmy.StatusBatteryFull)
 	if hasBattery {
-		status = batteryStatus(millivolts)
+		status = batteryStatus(millivolts, limits)
 		println("battery is", strconv.Itoa(int(millivolts)), "mV,", findmy.BatteryStatus(status))
 	}
 
@@ -154,7 +155,7 @@ func main() {
 			if !ok {
 				continue
 			}
-			newStatus := batteryStatus(millivolts)
+			newStatus := batteryStatus(millivolts, limits)
 			if newStatus == status {
 				continue
 			}

--- a/firmware/main_test.go
+++ b/firmware/main_test.go
@@ -57,23 +57,83 @@ func TestTxPower(t *testing.T) {
 }
 
 func TestBatteryStatus(t *testing.T) {
+	lipo := batteryProfiles["lipo"]
+	coin := batteryProfiles["cr2032"]
+
 	tests := []struct {
+		limits     batteryLimits
 		millivolts uint16
 		want       byte
 	}{
-		{4200, findmy.StatusBatteryFull},
-		{3900, findmy.StatusBatteryFull},
-		{3899, findmy.StatusBatteryMedium},
-		{3700, findmy.StatusBatteryMedium},
-		{3699, findmy.StatusBatteryLow},
-		{3500, findmy.StatusBatteryLow},
-		{3499, findmy.StatusBatteryCritical},
-		{0, findmy.StatusBatteryCritical},
+		{lipo, 4200, findmy.StatusBatteryFull},
+		{lipo, 3900, findmy.StatusBatteryFull},
+		{lipo, 3899, findmy.StatusBatteryMedium},
+		{lipo, 3700, findmy.StatusBatteryMedium},
+		{lipo, 3699, findmy.StatusBatteryLow},
+		{lipo, 3500, findmy.StatusBatteryLow},
+		{lipo, 3499, findmy.StatusBatteryCritical},
+		{lipo, 0, findmy.StatusBatteryCritical},
+		// A coin cell never gets to 3500 mV, so the LiPo values give
+		// "critical" for its whole life.
+		{lipo, 2800, findmy.StatusBatteryCritical},
+		{coin, 3000, findmy.StatusBatteryFull},
+		{coin, 2900, findmy.StatusBatteryFull},
+		{coin, 2899, findmy.StatusBatteryMedium},
+		{coin, 2800, findmy.StatusBatteryMedium},
+		{coin, 2749, findmy.StatusBatteryLow},
+		{coin, 2600, findmy.StatusBatteryLow},
+		{coin, 2599, findmy.StatusBatteryCritical},
 	}
 
 	for _, tc := range tests {
-		if got := batteryStatus(tc.millivolts); got != tc.want {
-			t.Errorf("%d mV: got %#x, want %#x", tc.millivolts, got, tc.want)
+		if got := batteryStatus(tc.millivolts, tc.limits); got != tc.want {
+			t.Errorf("%d mV with %v: got %#x, want %#x", tc.millivolts, tc.limits, got, tc.want)
+		}
+	}
+}
+
+// TestBatteryThresholds checks the values that BatteryType and
+// BatteryThresholds give.
+func TestBatteryThresholds(t *testing.T) {
+	// The other tests leave these values changed, so keep and put back the
+	// values that the build gave.
+	oldType, oldThresholds := BatteryType, BatteryThresholds
+	defer func() { BatteryType, BatteryThresholds = oldType, oldThresholds }()
+
+	lipo := batteryProfiles["lipo"]
+
+	tests := []struct {
+		batteryType string
+		thresholds  string
+		want        batteryLimits
+	}{
+		// No value is a LiPo cell.
+		{"", "", lipo},
+		{"lipo", "", lipo},
+		{"cr2032", "", batteryProfiles["cr2032"]},
+		{"cr1220", "", batteryProfiles["cr1220"]},
+		{"aa-alkaline", "", batteryProfiles["aa-alkaline"]},
+		// The raw values win over the name of the cell.
+		{"", "2900/2750/2600", batteryLimits{2900, 2750, 2600}},
+		{"lipo", "2900/2750/2600", batteryLimits{2900, 2750, 2600}},
+		// A value that is not usable falls back to the LiPo cell.
+		{"nosuchcell", "", lipo},
+		{"", "2900/2750", lipo},
+		{"", "2900/2750/2600/2500", lipo},
+		{"", "2600/2750/2900", lipo},
+		{"", "2900/2900/2600", lipo},
+		{"", "2900/2750/0", lipo},
+		{"", "2900/abc/2600", lipo},
+		{"", "-2900/2750/2600", lipo},
+		{"", "70000/2750/2600", lipo},
+		{"", "//", lipo},
+	}
+
+	for _, tc := range tests {
+		BatteryType, BatteryThresholds = tc.batteryType, tc.thresholds
+		if got := batteryThresholds(); got != tc.want {
+			t.Errorf("BatteryType=%q BatteryThresholds=%q: got %v, want %v",
+				tc.batteryType, tc.thresholds, got, tc.want)
 		}
 	}
 }
@@ -104,7 +164,7 @@ func TestBatteryMillivolts(t *testing.T) {
 			t.Errorf("%s: got %d mV, want %d mV", tc.board, got, tc.want)
 		}
 		// Every board must read a full battery as full.
-		if s := batteryStatus(got); s != findmy.StatusBatteryFull {
+		if s := batteryStatus(got, batteryProfiles["lipo"]); s != findmy.StatusBatteryFull {
 			t.Errorf("%s: %d mV gives status %#x, want full", tc.board, got, s)
 		}
 	}

--- a/firmware/mcu.go
+++ b/firmware/mcu.go
@@ -27,6 +27,15 @@ var BatteryPin string
 // single number is a ratio to 1. An empty value stops the reading.
 var BatteryDivider string
 
+// BatteryType names the cell that the beacon uses, such as "cr2032". An empty
+// value is a single cell LiPo. Set it with -ldflags "-X main.BatteryType=cr2032".
+var BatteryType string
+
+// BatteryThresholds gives the full, medium and low voltages in millivolts, such
+// as "2900/2750/2600". It wins over BatteryType. An empty value keeps the
+// values of the cell that BatteryType names.
+var BatteryThresholds string
+
 // KeyRotation is how long the beacon uses each key, such as "5m". An empty
 // value keeps the first key for ever. Set it with
 // -ldflags "-X main.KeyRotation=5m".

--- a/firmware/os.go
+++ b/firmware/os.go
@@ -41,3 +41,11 @@ var BatteryPin string
 // BatteryDivider is the ratio of the battery divider. An operating system does
 // not give this control, so it stays empty here.
 var BatteryDivider string
+
+// BatteryType names the cell that the beacon uses. An operating system does not
+// read a battery here, so it stays empty.
+var BatteryType string
+
+// BatteryThresholds gives the battery voltage thresholds. An operating system
+// does not read a battery here, so it stays empty.
+var BatteryThresholds string


### PR DESCRIPTION
## What this changes

The battery thresholds were for a single cell LiPo only. A 3 V coin cell never gets above 3500 mV, so a beacon on a CR2032 or a CR1220 reported a critical battery for its whole life. The only fix was to change the constants in `firmware/battery.go` and build again.

Two new build time values now set the thresholds:

- `BatteryType` names a cell in a table of profiles: `lipo` (the default), `cr2032`, `cr1220` and `aa-alkaline`.
- `BatteryThresholds` gives the full, medium and low voltages in millivolts, such as `2900/2750/2600`, for a cell that is not in the table. It wins over `BatteryType`.

The `haystack` tool gives them with `-batterytype` and `-batterythresholds`:

```shell
haystack -batterytype=cr2032 flash DEVICENAME xiao-ble
haystack -batterythresholds=2900/2750/2600 flash DEVICENAME xiao-ble
```

A value that is not usable prints a message and falls back to the LiPo values, in the same way as a bad `BatteryPin`, so a wrong value cannot stop the beacon.

## Why the capacity is not an input

The thresholds come from the discharge curve of the cell and not from its capacity in mAh. A CR2032 and a CR1220 are the same lithium chemistry and have almost the same curve. The CR1220 holds much less charge, so it is empty much sooner, but the voltage at which it is empty is nearly the same. Its internal resistance is higher, so it sags more when the radio transmits, and its thresholds are 50 mV higher for this reason. The status byte holds only four states, so a state of charge in percent has nowhere to go.

## Tests

- `go vet ./...` and `go test ./...` pass. `TestBatteryStatus` now covers a coin cell, and `TestBatteryThresholds` covers each profile, the raw values, and every value that is not usable.
- `tinygo build` passes for `xiao-ble`, `nicenano`, `feather-nrf52840` and `xiao-esp32c3`, and also with a bad `BatteryType` and a bad `BatteryThresholds`.