### PR TITLE
tinyscan: show the devices of the owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ TinyScan runs on several different microcontrollers boards with Bluetooth and mi
 
 The TinyScan code is located in the [tinyscan](./tinyscan/) directory in this repository.
 
+TinyScan can also show the names of your own devices. Flash it with the same device
+names that you used with `haystack keys`, and it then shows the name of the device
+with a `*` mark instead of the key:
+
+```shell
+haystack flashscan clue blackgopher redgopher
+```
+
+Add `-onlymine` to hide every beacon that is not one of your devices. See
+[TinyScan](./tinyscan/README.md#your-own-devices) for more information.
+
 ## How to install
 
 ### Apple ID

--- a/cmd/haystack/flashscan.go
+++ b/cmd/haystack/flashscan.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// scanOptions holds the build settings for the scanner.
+type scanOptions struct {
+	verbose  bool
+	onlyMine bool
+}
+
+// scannerStackSize is the stack that the TinyScan firmware needs.
+const scannerStackSize = "8kb"
+
+// flashScanner builds the TinyScan firmware with the keys of the given devices
+// and flashes it to the target.
+func flashScanner(target string, names []string, opts scanOptions) error {
+	keys := make([][]string, 0, len(names))
+	for _, name := range names {
+		if strings.ContainsAny(name, "=,;") {
+			return fmt.Errorf("bad device name %q, it must have no '=' ',' or ';'", name)
+		}
+
+		k, err := readKeys(name)
+		if err != nil {
+			return err
+		}
+		keys = append(keys, k)
+	}
+
+	pwd := os.Getenv("PWD")
+	pth := filepath.Join(pwd, "tinyscan")
+	if err := os.Chdir(pth); err != nil {
+		return err
+	}
+	defer os.Chdir(pwd)
+
+	args := []string{"flash", "-target", target, "-stack-size", scannerStackSize}
+	if flags := scannerLDFlags(names, keys, opts.onlyMine); flags != "" {
+		args = append(args, "-ldflags", flags)
+	}
+	args = append(args, ".")
+
+	if opts.verbose {
+		fmt.Println("tinygo", strings.Join(args, " "))
+	}
+
+	cmd := exec.Command("tinygo", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// scannerLDFlags returns the linker flags that give the scanner the devices of
+// the owner. It returns an empty string if there is nothing to set.
+func scannerLDFlags(names []string, keys [][]string, onlyMine bool) string {
+	var flags []string
+
+	if len(names) > 0 {
+		devices := make([]string, 0, len(names))
+		for i, name := range names {
+			devices = append(devices, name+"="+strings.Join(keys[i], ","))
+		}
+		flags = append(flags, fmt.Sprintf("-X main.MyDevices='%s'", strings.Join(devices, ";")))
+	}
+
+	if onlyMine {
+		flags = append(flags, "-X main.OnlyMine=true")
+	}
+
+	return strings.Join(flags, " ")
+}

--- a/cmd/haystack/flashscan_test.go
+++ b/cmd/haystack/flashscan_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestScannerLDFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		names    []string
+		keys     [][]string
+		onlyMine bool
+		want     string
+	}{
+		{"no devices", nil, nil, false, ""},
+		{"one device", []string{"demo"}, [][]string{{"AAA"}}, false, "-X main.MyDevices='demo=AAA'"},
+		{"more keys", []string{"demo"}, [][]string{{"AAA", "BBB"}}, false, "-X main.MyDevices='demo=AAA,BBB'"},
+		{"two devices", []string{"demo", "other"}, [][]string{{"AAA"}, {"BBB", "CCC"}}, false,
+			"-X main.MyDevices='demo=AAA;other=BBB,CCC'"},
+		{"only mine", []string{"demo"}, [][]string{{"AAA"}}, true,
+			"-X main.MyDevices='demo=AAA' -X main.OnlyMine=true"},
+		{"only mine with no devices", nil, nil, true, "-X main.OnlyMine=true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scannerLDFlags(tc.names, tc.keys, tc.onlyMine)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/haystack/main.go
+++ b/cmd/haystack/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // usage names the subcommands of the tool.
-const usage = "subcommand required. valid subcommands are 'keys' 'flash' 'scan' 'version'"
+const usage = "subcommand required. valid subcommands are 'keys' 'flash' 'flashscan' 'scan' 'version'"
 
 func main() {
 	verboseFlag := flag.Bool("v", false, "enable verbose mode")
@@ -26,6 +26,7 @@ func main() {
 	batteryTypeFlag := flag.String("batterytype", "", "cell that the beacon uses, one of lipo, cr2032, cr1220 or aa-alkaline. Empty is lipo")
 	batteryThresholdsFlag := flag.String("batterythresholds", "", "full, medium and low battery voltages in millivolts, for example 2900/2750/2600. It wins over -batterytype")
 	keysFlag := flag.Int("keys", defaultKeyCount, "how many keys to generate for a device, which the beacon then uses in turn")
+	onlyMineFlag := flag.Bool("onlymine", false, "the scanner shows only your own devices")
 	rotateFlag := flag.String("rotate", defaultKeyRotation, "how long the beacon uses each key, for example 5m. An empty value stops the rotation")
 	flag.Parse()
 
@@ -62,6 +63,18 @@ func main() {
 		}
 		if err := flashDevice(args[1], args[2], opts); err != nil {
 			fmt.Println("failed to flash device:", err)
+		}
+	case "flashscan":
+		if len(args) < 2 {
+			fmt.Println("Please provide a target")
+			return
+		}
+		opts := scanOptions{
+			verbose:  *verboseFlag,
+			onlyMine: *onlyMineFlag,
+		}
+		if err := flashScanner(args[1], args[2:], opts); err != nil {
+			fmt.Println("failed to flash scanner:", err)
 		}
 	case "scan":
 		if err := scanDevices(verboseFlag); err != nil {

--- a/lib/findmy/data.go
+++ b/lib/findmy/data.go
@@ -19,6 +19,9 @@ const (
 	// Length of the payload
 	PayloadLength = 0x19
 
+	// Length of an advertisement key
+	KeyLength = 28
+
 	// Hint byte
 	Hint = 0x00
 
@@ -73,7 +76,7 @@ func ParseData(mac bluetooth.MAC, data []byte) (byte, []byte, error) {
 	}
 
 	findMyStatus := data[2]
-	var key [28]byte
+	var key [KeyLength]byte
 	copy(key[6:], data[3:25])
 
 	// turn address into key bytes

--- a/lib/findmy/devices.go
+++ b/lib/findmy/devices.go
@@ -1,0 +1,96 @@
+package findmy
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+var (
+	ErrorNoDeviceName = errors.New("findmy: device has no name")
+	ErrorNoDeviceKeys = errors.New("findmy: device has no keys")
+	ErrorInvalidKey   = errors.New("findmy: advertisement key must be 28 bytes")
+)
+
+// Device is a device of the owner, with the advertisement keys that it uses.
+type Device struct {
+	Name string
+	Keys [][]byte
+}
+
+// ParseDevices reads a list of devices such as "name=KEY1,KEY2;name2=KEY3".
+// The keys are base64 and 28 bytes long.
+func ParseDevices(s string) ([]Device, error) {
+	var devices []Device
+	for _, part := range strings.Split(s, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		name, list, found := strings.Cut(part, "=")
+		name = strings.TrimSpace(name)
+		if !found || name == "" {
+			return nil, ErrorNoDeviceName
+		}
+
+		device := Device{Name: name}
+		for _, key := range strings.Split(list, ",") {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+
+			val, err := base64.StdEncoding.DecodeString(key)
+			if err != nil {
+				return nil, err
+			}
+			if len(val) != KeyLength {
+				return nil, ErrorInvalidKey
+			}
+
+			device.Keys = append(device.Keys, val)
+		}
+
+		if len(device.Keys) == 0 {
+			return nil, ErrorNoDeviceKeys
+		}
+
+		devices = append(devices, device)
+	}
+
+	return devices, nil
+}
+
+// Lookup returns the name of the device that uses the key.
+func Lookup(devices []Device, key []byte) (string, bool) {
+	for _, device := range devices {
+		for _, k := range device.Keys {
+			if SameKey(key, k) {
+				return device.Name, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// SameKey reports if the key from a scan is the key of a device. The BLE
+// address keeps only 6 bits of byte 0, so the other 2 bits are not compared.
+func SameKey(a, b []byte) bool {
+	if len(a) != KeyLength || len(b) != KeyLength {
+		return false
+	}
+
+	if a[0]&0x3F != b[0]&0x3F {
+		return false
+	}
+
+	for i := 1; i < KeyLength; i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/lib/findmy/devices_test.go
+++ b/lib/findmy/devices_test.go
@@ -1,0 +1,132 @@
+package findmy
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// testKey is a valid 28 byte advertisement key, base64 encoded.
+const testKey = "UUksYlEEXUmIjb5h9naEnv4ZcdocNWATRE3+Xg=="
+
+const otherKey = "TEsWX7q3MVAb8lhfzYCmMSvDRq3BFC8ltWWC4A=="
+
+func TestParseDevices(t *testing.T) {
+	first, err := base64.StdEncoding.DecodeString(testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := base64.StdEncoding.DecodeString(otherKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		val  string
+		want []Device
+	}{
+		{"empty", "", nil},
+		{"one device", "demo=" + testKey, []Device{{Name: "demo", Keys: [][]byte{first}}}},
+		{"two keys", "demo=" + testKey + "," + otherKey, []Device{{Name: "demo", Keys: [][]byte{first, second}}}},
+		{"two devices", "demo=" + testKey + ";other=" + otherKey, []Device{
+			{Name: "demo", Keys: [][]byte{first}},
+			{Name: "other", Keys: [][]byte{second}},
+		}},
+		{"spaces", " demo = " + testKey + " ; ", []Device{{Name: "demo", Keys: [][]byte{first}}}},
+		{"empty key", "demo=" + testKey + ",,", []Device{{Name: "demo", Keys: [][]byte{first}}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseDevices(tc.val)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d devices, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if got[i].Name != tc.want[i].Name {
+					t.Errorf("device %d is %q, want %q", i, got[i].Name, tc.want[i].Name)
+				}
+				if len(got[i].Keys) != len(tc.want[i].Keys) {
+					t.Fatalf("device %d has %d keys, want %d", i, len(got[i].Keys), len(tc.want[i].Keys))
+				}
+				for j := range got[i].Keys {
+					if string(got[i].Keys[j]) != string(tc.want[i].Keys[j]) {
+						t.Errorf("device %d key %d is wrong", i, j)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseDevicesErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+	}{
+		{"no name", "=" + testKey},
+		{"no separator", testKey},
+		{"no keys", "demo="},
+		{"bad base64", "demo=????"},
+		{"short key", "demo=SGVsbG8="},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseDevices(tc.val); err == nil {
+				t.Error("expected an error, got none")
+			}
+		})
+	}
+}
+
+func TestSameKey(t *testing.T) {
+	key := []byte{0x0e, 0x8b, 0xad, 0x5f, 0x8a, 0x02, 0x71, 0x53, 0x8f, 0xf5, 0xaf, 0xda, 0x87, 0x49, 0x8c, 0xb0, 0x67, 0xe9, 0xa0, 0x20, 0xd6, 0xe4, 0x16, 0x78, 0x01, 0xd5, 0x5d, 0x83}
+
+	// A key from a scan holds the bits of the random static address in byte 0.
+	scanned := make([]byte, KeyLength)
+	copy(scanned, key)
+	scanned[0] |= 0xC0
+
+	if !SameKey(scanned, key) {
+		t.Error("a key with the address bits must match")
+	}
+	if !SameKey(key, key) {
+		t.Error("a key must match itself")
+	}
+
+	other := make([]byte, KeyLength)
+	copy(other, key)
+	other[27] ^= 0x01
+	if SameKey(scanned, other) {
+		t.Error("a different key must not match")
+	}
+
+	if SameKey(key[:27], key) {
+		t.Error("a short key must not match")
+	}
+}
+
+func TestLookup(t *testing.T) {
+	devices, err := ParseDevices("demo=" + testKey + ";other=" + otherKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scanned := make([]byte, KeyLength)
+	copy(scanned, devices[1].Keys[0])
+	scanned[0] |= 0xC0
+
+	name, found := Lookup(devices, scanned)
+	if !found || name != "other" {
+		t.Errorf("got %q %v, want \"other\" true", name, found)
+	}
+
+	unknown := make([]byte, KeyLength)
+	if _, found := Lookup(devices, unknown); found {
+		t.Error("an unknown key must not match")
+	}
+}

--- a/tinyscan/README.md
+++ b/tinyscan/README.md
@@ -52,6 +52,35 @@ https://www.adafruit.com/product/4116
 tinygo flash -target pyportal -stack-size 8kb .
 ```
 
+## Your own devices
+
+TinyScan can show the name of your own devices. Give it the advertisement keys of
+each device at build time, and a beacon that uses one of those keys then shows the
+name of the device with a `*` mark instead of the key.
+
+The `haystack` tool reads the keys from the `.keys` files and builds the command
+for you. Use the same device names that you used with `haystack keys`:
+
+```shell
+haystack flashscan clue blackgopher redgopher
+```
+
+Add `-onlymine` to hide every other beacon:
+
+```shell
+haystack -onlymine flashscan clue blackgopher redgopher
+```
+
+To do it by hand, put the base64 advertisement keys in the `MyDevices` flag. Each
+device is a name, an `=` sign and its keys separated by commas. A `;` separates
+the devices:
+
+```shell
+tinygo flash -target clue -stack-size 8kb -ldflags="-X main.MyDevices='blackgopher=KEY1,KEY2;redgopher=KEY3'" .
+```
+
+Add `-X main.OnlyMine=true` to the same `ldflags` value to hide every other beacon.
+
 ## Debugging
 
 To show scanning errors on the TinyScan display, use the `ldflags` flag in your flash command like this:

--- a/tinyscan/main.go
+++ b/tinyscan/main.go
@@ -20,10 +20,29 @@ var (
 	adapter = bluetooth.DefaultAdapter
 
 	showErrors string
+
+	// MyDevices holds the devices of the owner, such as
+	// "name=KEY1,KEY2;name2=KEY3". The keys are the base64 advertisement keys.
+	// Set it with -ldflags "-X main.MyDevices=...".
+	MyDevices string
+
+	// OnlyMine hides every beacon that is not a device of the owner. Set it to
+	// "true" with -ldflags "-X main.OnlyMine=true".
+	OnlyMine string
+
+	devices []findmy.Device
 )
 
 func main() {
 	initTerminal()
+
+	// A bad list of devices must not stop the scan.
+	var err error
+	devices, err = findmy.ParseDevices(MyDevices)
+	if err != nil {
+		terminalOutput("ERROR: failed to parse devices:" + err.Error())
+	}
+	terminalOutput(fmt.Sprintf("known devices: %d", len(devices)))
 
 	terminalOutput("enable interface...")
 
@@ -43,19 +62,33 @@ func main() {
 func scanHandler(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
 	if device.ManufacturerData() != nil && device.ManufacturerData()[0].CompanyID == findmy.AppleCompanyID {
 		status, key, err := findmy.ParseData(device.Address.MAC, device.ManufacturerData()[0].Data)
-		terminalOutput("--------------------------------")
 		switch {
 		case err != nil && err == findmy.ErrorUnregistered:
+			if OnlyMine != "" {
+				return
+			}
+			terminalOutput("--------------------------------")
 			terminalOutput(fmt.Sprintf("%s %d (unregistered)", device.Address.String(), device.RSSI))
 			return
 		case err != nil:
 			if showErrors != "" {
+				terminalOutput("--------------------------------")
 				terminalOutput("ERROR: failed to parse data:" + err.Error())
 			}
 			return
 		}
 
+		name, mine := findmy.Lookup(devices, key)
+		if !mine && OnlyMine != "" {
+			return
+		}
+
+		terminalOutput("--------------------------------")
 		terminalOutput(fmt.Sprintf("%s %d (battery %s)", device.Address.String(), device.RSSI, findmy.BatteryStatus(status)))
+		if mine {
+			terminalOutput("* " + name)
+			return
+		}
 		terminalOutput(hex.EncodeToString(key))
 	}
 }


### PR DESCRIPTION
## Problem

TinyScan shows every FindMy beacon near it with its key in hex. Nothing tells you
which beacon is one of your own devices, so you must compare the key on the screen
with the base64 keys in your `.keys` files by hand.

## Solution

The build gives TinyScan the advertisement keys of your devices in the new
`MyDevices` variable, such as `name=KEY1,KEY2;name2=KEY3`. A beacon that uses one
of those keys shows the name of the device with a `*` mark instead of the key.
`OnlyMine` hides every other beacon.

The `haystack` tool gets a `flashscan` subcommand that reads the `.keys` file of
each device and builds TinyScan with the keys:

```shell
haystack flashscan clue blackgopher redgopher
haystack -onlymine flashscan clue blackgopher redgopher
```

`findmy.ParseDevices`, `findmy.Lookup` and `findmy.SameKey` are in the shared
library, where the tests run on the host. A key from a scan keeps only 6 bits of
byte 0, because the BLE address sets the 2 top bits, so `SameKey` does not compare
those bits.

## Test

- `go build ./... && go vet ./... && go test ./...`
- `tinygo build -o /dev/null -size short -stack-size 8kb -target=clue ./tinyscan`
- `tinygo build -o /dev/null -size short -stack-size 8kb -target=badger2040-w ./tinyscan`
- A build of the `clue` target with the keys of a device holds the keys in the binary.